### PR TITLE
Add word-wrap to contribute cards

### DIFF
--- a/css/brackets.io.css
+++ b/css/brackets.io.css
@@ -320,6 +320,7 @@ blockquote p {
     line-height: 1.5;
     margin-bottom: 1.25em;
     padding: 0.5em 0.7em;
+    word-wrap: break-word;
 }
 
 .card footer {


### PR DESCRIPTION
Before:
![image](https://f.cloud.github.com/assets/2641501/1460787/c07af86e-4470-11e3-8a28-a654579e5435.png)

After:
![image](https://f.cloud.github.com/assets/2641501/1460786/bc44a790-4470-11e3-86b8-778e576b69d9.png)

This change is especially important for the mobile site.
