### PR TITLE
Switch GitHub Username & Real Name

### DIFF
--- a/contribute.html
+++ b/contribute.html
@@ -245,7 +245,7 @@
                 </li>
                 <li>
                     <img src="https://1.gravatar.com/avatar/fdb97845567e909fd6a988450cebf94f?d=https%3A%2F%2Fidenticons.github.com%2F1233fd6ebd19e5458fb9ef15c548aa23.png&s=420" alt="avatar"/>
-                    dloverin (<a href="https://github.com/dloverin">Darrell Loverin</a>)
+                    Darrell Loverin (<a href="https://github.com/dloverin">dloverin</a>)
                 </li>
                 <li>
                     <img src="https://secure.gravatar.com/avatar/609a2d279ffaef9379fb07baab8b5b47?s=420&d=https://a248.e.akamai.net/assets.github.com%2Fimages%2Fgravatars%2Fgravatar-user-420.png" alt="avatar"/>


### PR DESCRIPTION
Contributor's name and GitHub username were reversed (as compared to everyone else)
