### PR TITLE
TEMP HACK: hard-code version 34 to temporarily fix download button

### DIFF
--- a/index.html
+++ b/index.html
@@ -282,7 +282,11 @@
         $.getJSON('http://dev.brackets.io/updates/stable/en.json', function(data){
             // assume first entry is latest
             var build = data[0];
-            build.version = build.versionString.substr(build.versionString.indexOf(' ') + 1, build.versionString.length);
+            
+            // TEMPORARY: hard-code version 34
+            //build.version = build.versionString.substr(build.versionString.indexOf(' ') + 1, build.versionString.length);
+            build.version = 34;
+            
             // update button
             if(OS != "OTHER"){
                 var version_label = build.versionString;


### PR DESCRIPTION
@adrocknaphobia This is just a temporary hack to make the download button on brackets.io work for the Sprint 34 hotfix until you can take a look at it.
