### PR TITLE
Display 'Sprint' before version number

### DIFF
--- a/index.html
+++ b/index.html
@@ -323,7 +323,7 @@
             // update button
             if (OS != "OTHER") {
                 var version_label = "";
-                if (OS != "UNKNOWN") version_label = build + ' (' + OS + ')';
+                if (OS != "UNKNOWN") version_label = 'Sprint ' + build + ' (' + OS + ')';
                 /*
                 var version_label = build.versionString;
                 var version_url = build.downloadURL;


### PR DESCRIPTION
@peterflynn Just a quick fix to display "Sprint" before the version number as it was before the download.brackets.io server issue today (adobe/brackets#7239), as shown in the screenshots.

Before issues (image from Google Cache):

![screenshot 90](https://f.cloud.github.com/assets/3382464/2454275/44598d12-aee8-11e3-9bcb-7bc56652424b.png)

Live site:

![screenshot 93](https://f.cloud.github.com/assets/3382464/2454269/3992edc4-aee8-11e3-8b64-bd6cc2f5b297.png)
