### PR TITLE
[REVIEW ONLY] - All downloads menu from downloads.brackets.io

### DIFF
--- a/download/css/download.css
+++ b/download/css/download.css
@@ -284,13 +284,13 @@ blockquote p {
 }
 
 #hero-message a,
-#other-downloads {
+#all-downloads {
     color: #7dfffa;
     font-weight: 600;
     text-shadow: 0 1px 2px rgba(0, 0, 0, 0.2);
 }
 
-#other-downloads {
+#all-downloads {
     font-size: .7em;
 }
 
@@ -552,4 +552,85 @@ only screen and (min-device-pixel-ratio: 2) {
         /* Translate the 2x sprite's dimensions back to 1x */
         background-size: 258px 124px;
     }
+}
+
+
+/* Downloads list
+------------------------------------------------------------------- */
+
+#downloads-list {
+  display: inline-block;
+  background: #dfe2e2;
+  position: absolute;
+  top: 100%;
+  right: 67px;
+  z-index: 50;
+  opacity: 0;
+  border-bottom-left-radius: 3px;
+  border-bottom-right-radius: 3px;
+  border-left: 1px solid #797b7b;
+  border-right: 1px solid #797b7b;
+  border-bottom: 1px solid #797b7b;
+  box-shadow: 0 2px 5px rgba(0,0,0,0.25);
+  padding: 10px;
+  min-width: 200px;
+  text-align: left;
+  -webkit-transition: opacity 0.5s ease-out;
+     -moz-transition: opacity 0.5s ease-out;
+          transition: opacity 0.5s ease-out;
+}
+
+#downloads-list.show {
+  opacity: 1;
+}
+
+#downloads-list a {
+  color: #178fca;
+  text-decoration: none;
+}
+
+#downloads-list a:hover {
+  text-decoration: underline;
+}
+
+#downloads-list li span {
+  font-weight: 300;
+  font-size: 13px;
+  color: #666;
+}
+
+#downloads-list section {
+  margin-bottom: 30px;
+}
+
+#downloads-list section:last-child {
+  margin-bottom: 0;
+}
+
+#downloads-list section h3 {
+  font-weight: 500;
+  font-size: 21px;
+  margin-bottom: 2px;
+}
+
+#downloads-list section h4 {
+  font-weight: 300;
+  font-size: 13px;
+  margin-bottom: 3px;
+  margin-left: 2px;
+}
+
+ #downloads-list section a.notes {
+  font-weight: 300;
+  font-size: 13px;
+  margin: 0 0 0 20px;
+}
+
+#downloads-list section ul {
+  list-style: none;
+  margin: 5px 0 0 20px;
+}
+
+#downloads-list section ul a {
+  font-weight: 600;
 }

--- a/download/download.html
+++ b/download/download.html
@@ -99,8 +99,9 @@
                 <p>New features in Brackets are released often (about every 3 weeks). When new features are available you will see a gift icon inside the application. For the latest release information, follow Brackets on <a href="http://www.twitter.com/brackets">Twitter</a> or <a href="https://plus.google.com/u/0/b/115365194873502050036/115365194873502050036">Google+</a>.</p>
                 <div id="download">
                     <a id="hero-cta-button" href="#" class="large rounded radius button">Download Brackets <span id="download-version">Sprint 31</span></a>
-                    <p><a id="other-downloads" href="http://download.brackets.io">Other Downloads</a></p>
+                    <p><a id="all-downloads" href="#" onclick="toggleDownloads(); return false;">All Downloads</a></p>
                 </div>
+               <div id="downloads-list"></div>
             </div>
         </div>
     </div>
@@ -120,7 +121,7 @@
 
             <h3>Improved Linting API</h3>
             <p>Extension authors can now drive linting engine headlessly.</p>
-            
+
             <h3>Updated Translations</h3>
             <p>French, Japanese, German, Czech, Finnish, and Turkish translations have been updated.</p>
         </div>
@@ -135,7 +136,7 @@
                 <li>200MB of available hard-disk space for installation</li>
                 <li>1280x800 display with 16-bit video card</li>
             </ul>
-            
+
             <h3>Windows</h3>
             <ul>
                 <li>Intel® Pentium® 4 or AMD Athlon® 64 processor</li>
@@ -217,48 +218,133 @@
     </script>
 
     <script>
-        var OS = "UNKNOWN";
+        var version_url, ext,
+            feed = "http://dev.brackets.io/updates/stable/en.json",
+            OS = "UNKNOWN",
+            github_url = "https://github.com/adobe/brackets/releases/download/";
+
         if (navigator.userAgent.indexOf("Win32") != -1 ||
             navigator.userAgent.indexOf("WOW64") != -1 ||
-            navigator.userAgent.indexOf("Win64") != -1 ) OS = "WIN";
-        if (navigator.platform.indexOf("Mac") != -1) OS = "OSX";
+            navigator.userAgent.indexOf("Win64") != -1) {OS = "WIN"; ext=".msi";};
+        if (navigator.platform.indexOf("Mac") != -1) {OS = "OSX"; ext=".dmg";};
         if (navigator.appVersion.indexOf("X11") != -1 ||
             navigator.appVersion.indexOf("Linux") != -1) {
-            OS = "LINUX32";
-            if (navigator.appVersion.indexOf("x86_64") != -1) OS = "LINUX64";
+            OS = "LINUX32"; ext=".32-bit.deb";
+            if (navigator.appVersion.indexOf("x86_64") != -1) {OS = "LINUX64"; ext=".64-bit.deb";}
         }
         if (navigator.userAgent.indexOf("iPad") != -1 ||
             navigator.userAgent.indexOf("iPod") != -1 ||
             navigator.userAgent.indexOf("iPhone") != -1 ||
             navigator.userAgent.indexOf("Android") != -1) OS = "OTHER";
-        if(OS == "OTHER"){
+        if (OS == "OTHER") {
             document.getElementById("download").style.display = "none";
         }
 
-        $.getJSON('http://dev.brackets.io/updates/stable/en.json', function(data){
-            // assume first entry is latest
+        $.getJSON(feed, function(data) {
+          "use strict";
+            // Assume first entry is latest release
             var build = data[0];
+
+            // Create GitHub tag name
+            build.tagname = build.versionString.toLowerCase().replace(/\s/g, "-");
             build.version = build.versionString.substr(build.versionString.indexOf(' ') + 1, build.versionString.length);
-            // update button
-            if(OS != "OTHER"){
+
+            // Update button
+            if (OS != "OTHER") {
                 var version_label = build.versionString;
                 var version_url = build.downloadURL;
-                if(OS != "Unknown") {
+                if (OS != "Unknown") {
                     version_label = version_label + ' (' + OS + ')';
-                    version_url = "http://download.brackets.io/file.cfm?platform=" + OS + "&build=" + build.version;
+                    github_url = "https://github.com/adobe/brackets/releases/download/";
+                    window.version_url = build.tagname + "/Brackets.Sprint."+ build.version + ext;
                 }
                 document.getElementById("download-version").innerHTML = version_label;
-                document.getElementById("hero-cta-button").href = version_url;
+                document.getElementById("hero-cta-button").href = github_url + window.version_url;
             }
-            // update features (limit 5)
+
+            // Update features (limit 5)
             var feature_content = "<h2>New Features in " + build.versionString + "</h2>";
-            for(i = 0; i < Math.min(build.newFeatures.length, 5); i++) {
+            for(var i = 0; i < Math.min(build.newFeatures.length, 5); i++) {
                 feature_content = feature_content + "<h3>" + build.newFeatures[i].name + "</h3>";
                 feature_content = feature_content + "<p>" + build.newFeatures[i].description + "</p>";
             }
             feature_content = feature_content + '<p><a href="' + build.releaseNotesURL + '">More in the release notes.</a></p>';
             document.getElementById("features").innerHTML = feature_content;
         });
+
+
+      function getReleaseInfo(data, index) {
+        "use strict";
+        var build = data[index];
+
+        // Platform names and installer extensions
+        var platforms = {
+          "WIN": ".msi",
+          "OSX": ".dmg",
+          "LINUX32":".32-bit.deb",
+          "LINUX64": ".64-bit.deb"
+        },
+            platformLinks = [];
+
+        // Create GitHub tag name
+        build.tagname = build.versionString.toLowerCase().replace(/\s/g, "-");
+        build.version = build.versionString.substr(build.versionString.indexOf(' ') + 1, build.versionString.length);
+
+        var version_label = build.versionString;
+        var version_url = build.downloadURL;
+
+        // Construct each string
+        $.each(platforms, function(OS, ext) {
+          window.version_url = build.tagname + "/Brackets.Sprint."+ build.version + ext;
+          platformLinks.push([github_url + window.version_url, OS]);
+        });
+
+        return platformLinks;
+      }
+
+      function toggleDownloads() {
+        "use strict";
+        var dateRegex = /(\d+)-(\d+)-(\d+)/,
+            options = {year: "numeric", month: "long", day: "numeric"};
+
+        $.getJSON(feed, function(data) {
+          $(data).forEach(function (value, index) {
+            // Convert each date to the proper format
+            var dateComponents = data[index].dateString.match(dateRegex),
+                postingDate = new Date(dateComponents[3],
+                                       dateComponents[1] - 1, // Zero based month
+                                       dateComponents[2]);
+            var finalDate = postingDate.toLocaleDateString("en-US", options);
+
+            // Firefox does not automatically remove the day
+            if (navigator.userAgent.indexOf("Firefox") > -1 ) {
+              finalDate = finalDate.substr(finalDate.indexOf(",") + 1, finalDate.length);
+            }
+
+            // Get the URLs to each release
+            var platformURLs = getReleaseInfo(data, index),
+                releaseInfo = "<section><header>",
+                releaseInfoClosing = "</ul></section>";
+
+            // Add release name and date released
+            releaseInfo += "<h3>" + data[index].versionString + "</h3><h4>" + finalDate + "</h4></header>";
+
+            // Add release notes link
+            releaseInfo += '<div class="release-content"><a class="notes" href="' + data[index].releaseNotesURL + '">Release Notes</a></div><ul>'
+
+            // Add download links
+            $(platformURLs).forEach(function (value, index) {
+              releaseInfo += '<li><a href="' + value[0] + '">' + value[1] + '</a> <span>(' + value[0].substring(value[0].length, value[0].length - 3) + ')</span></li>';
+            });
+
+            // Add the content to the container
+            $("#downloads-list").append(releaseInfo + releaseInfoClosing);
+          });
+
+          // Finally, show the container
+          $("#downloads-list").toggleClass("show");
+        });
+      }
     </script>
 
     <script type="text/javascript">


### PR DESCRIPTION
In light of adobe/brackets#7239 and various discussion I've seen about a new downloads page (which I presume to be this), I recreated the All Downloads menu from http://downloads.brackets.io, using a mix of existing and new code. I also performed some minor `"use strict";` and other fixes. 
- Uses GitHub Release links for downloads. Yes, it would require having to go back and upload all the binaries for them, but GitHub Releases was built for this sort of thing.
- Copy relevant CSS from  http://downloads.brackets.io and reused it here. I also added a small CSS fade transition to match the shinyness of the site.
- Uses the preexisting `.json` file for data

**Issues**
- [ ] `window.version_url` is not ideal, IMO. I would think there is an easier way to make that a global variable.
- [ ] Most of the code would be better abstracted into a `.js` file for use on here and the index.
- [ ] Download size data is no longer available. Either the layout can be adjusted to compensate for the blank area (recommended), historical data can be gather to display approximate sizes, or the JSON feed can be changed to list the sizes in a comma-separated key (or some other character) matching the order of the downloads, which can then be broken up and displayed (this would be a last resort).
- [ ] The dropdown menu is _really_ long, and will only get longer with more releases.
- [ ] The information in the right column is out of date.
- [ ] I had a hard time with the menu placement. I ended up leaving it in the same location as downloads.brackets.io, but my initial plan was to center it under the download button. It worked except when I tested it on smaller screens. Some media queries would have taken care of that, but I didn't feel up to it.
