### PR TITLE
Fixed some of the contribute.html links

### DIFF
--- a/contribute.html
+++ b/contribute.html
@@ -74,10 +74,10 @@
                 <div class="nav clearfix">
                     <div class="nav-links">
                         <a href="index.html" class="home">Home</a>
-                        <a href="http://download.brackets.io" class="try-it">Download</a>
+                        <!--<a href="https://github.com/adobe/brackets/releases" class="try-it">Download</a>-->
                         <a href="contribute.html" class="contribute">Contribute</a>
                         <a href="http://blog.brackets.io">Blog</a>
-                        <a href="http://help.brackets.io">Support</a>
+                        <a href="https://github.com/adobe/brackets/wiki/Troubleshooting">Support</a>
                     </div>
                     <div class="social-links">
                         <a class="social-links-item github-icon" href="http://www.github.com/adobe/brackets" title="Github">Github</a>
@@ -281,7 +281,7 @@
                 <h2 id="contribute">Get Involved</h2>
                 <ul>
                     <li>
-                        <a href="http://help.brackets.io">Suggest a Feature</a>
+                        <a href="https://github.com/adobe/brackets/wiki/Suggest-a-Feature">Suggest a Feature</a>
                     </li>
                     <li>
                         <a href="http://groups.google.com/group/brackets-dev">Developer List on Google Groups</a>
@@ -300,27 +300,47 @@
             <div class="large-4 columns">
                 <h2 id="try-it">Videos</h2>
                 <ul>
-                    <li><a href="http://youtu.be/rvo3Mv1Z4qU">Introducing Brackets</a></li>
-                    <li><a href="http://youtu.be/Nhvj1NYC3Uc">Brackets Live Development for HTML</a></li>
-                    <li><a href="http://youtu.be/T6d5C3rLeFY">JavaScript Debugger for Brackets</a></li>
-                    <li><a href="http://youtu.be/xAP8CSMEwZ8">From Design Comp to Code</a></li>
-                    <li><a href="http://youtu.be/kXTP8XqrSwE">Reponsive Design Tool for Brackets</a></li>
+                    <li>
+                        <a href="http://youtu.be/rvo3Mv1Z4qU">Introducing Brackets</a>
+                    </li>
+                    <li>
+                        <a href="http://youtu.be/Nhvj1NYC3Uc">Brackets Live Development for HTML</a>
+                    </li>
+                    <li>
+                        <a href="http://youtu.be/T6d5C3rLeFY">JavaScript Debugger for Brackets</a>
+                    </li>
+                    <li>
+                        <a href="http://youtu.be/xAP8CSMEwZ8">From Design Comp to Code</a>
+                    </li>
+                    <li>
+                        <a href="http://youtu.be/kXTP8XqrSwE">Responsive Design Tool for Brackets</a>
+                    </li>
                 </ul>
 
             </div>
             <div class="large-4 columns">
                 <h2>Quick Links</h2>
                 <ul>
-                    <li><a href="https://github.com/adobe/brackets">Source Code</a></li>
-                    <li><a href="http://download.brackets.io/">Downloads</a></li>
-                    <li><a href="http://help.brackets.io">Troubleshooting Help</a></li>
-                    <li><a href="https://github.com/adobe/brackets/wiki">Wiki</a></li>
+                    <li>
+                        <a href="https://github.com/adobe/brackets">Source Code</a>
+                    </li>
+                    <li>
+                        <a href="http://download.brackets.io/">Downloads</a>
+                    </li>
+                    <li>
+                        <a href="https://github.com/adobe/brackets/wiki/Troubleshooting">Troubleshooting Help</a>
+                    </li>
+                    <li>
+                        <a href="https://github.com/adobe/brackets/wiki">Wiki</a>
+                    </li>
                 </ul>
             </div>
         </div>
         <div id="about" class="row">
             <div class="large-6 large-centered columns">
-                <p>Brackets was originally created by Adobe, but is maintained by the community.<br>The project is released under an <a href="https://github.com/adobe/brackets/blob/master/LICENSE">MIT License</a>.</p>
+                <p>Brackets was founded by Adobe as a community guided, open source project to push web development editors to the next level.
+                    <br>The project is released under an
+                    <a href="https://github.com/adobe/brackets/blob/master/LICENSE">MIT License</a>.</p>
             </div>
         </div>
     </div>


### PR DESCRIPTION
I copied it from index.html

I noticed that in both pages at the footer there is still a link to download.brackets.io. Should that be removed or link to https://github.com/adobe/brackets/releases?
