### PR TITLE
Remove obsolete installation instructions

### DIFF
--- a/index.html
+++ b/index.html
@@ -323,12 +323,6 @@ filter: none;
                 <li>Save the installer file to a location on your hard drive.</li>
                 <li>Locate the installer and double-click to start the install process.</li>
             </ol>
-            <ul>
-                <li>
-                    <strong>Mountain Lion (OS X 10.8)</strong> by default will not allow Brackets to run since it is not digitally signed. To work around this, right-click the Brackets .app and choose Open, then click Open on the dialog that appears. You only need to do this once.</li>
-                <li>
-                    <strong>Windows</strong> allows you to specify a custom install location. We do not recommend you install over an existing copy of Brackets.</li>
-            </ul>
         </div>
 
         <div class="description">


### PR DESCRIPTION
I don't think we need them anymore, because we now have
- signed installers (Mac, Windows)
- updating installers (no need to uninstall)
