### PR TITLE
CSS tweaks

### DIFF
--- a/contribute.html
+++ b/contribute.html
@@ -149,7 +149,7 @@
 
     <div id="content" class="row">
         <div class="large-4 columns">
-            <h2><a href="https://github.com/adobe/brackets/issues?labels=starter+bug&state=open" data-i18n="contribute.page.content.starter-issues.header">Starter Issues</a></h2>
+            <h2><a href="https://github.com/adobe/brackets/labels/starter%20bug" data-i18n="contribute.page.content.starter-issues.header">Starter Issues</a></h2>
             <p data-i18n="[html]contribute.page.content.starter-issues.description">Just getting started? Starter issues are bite-sized bugs that shouldn't take more than an hour or two to complete. They are a great way to learn the codebase <em>and</em> make a difference.</p>
             <div id="starter_issues">
                 <article class="card"><header><h3><a href="https://github.com/adobe/brackets/issues/5479">Unit tests should avoid expect().not.toBeNull() and .not.toBe(null)</a></h3></header><footer><div class="comment-count">4 comment(s)</div></footer></article>

--- a/contribute.html
+++ b/contribute.html
@@ -147,7 +147,7 @@
 
     <div id="content" class="row">
         <div class="large-4 columns">
-            <h2 data-i18n="contribute.page.content.starter-issues.header">Starter Issues</h2>
+            <h2><a href="https://github.com/adobe/brackets/issues?labels=starter+bug&state=open" class="subtle" data-i18n="contribute.page.content.starter-issues.header">Starter Issues</a></h2>
             <p data-i18n="[html]contribute.page.content.starter-issues.description">Just getting started? Starter issues are bite-sized bugs that shouldn't take more than an hour or two to complete. They are a great way to learn the codebase <em>and</em> make a difference.</p>
             <div id="starter_issues">
                 <article class="card"><header><h3><a href="https://github.com/adobe/brackets/issues/5479">Unit tests should avoid expect().not.toBeNull() and .not.toBe(null)</a></h3></header><footer><div class="comment-count">4 comment(s)</div></footer></article>

--- a/contribute.html
+++ b/contribute.html
@@ -149,7 +149,7 @@
 
     <div id="content" class="row">
         <div class="large-4 columns">
-            <h2><a href="https://github.com/adobe/brackets/issues?labels=starter+bug&state=open" class="subtle" data-i18n="contribute.page.content.starter-issues.header">Starter Issues</a></h2>
+            <h2><a href="https://github.com/adobe/brackets/issues?labels=starter+bug&state=open" data-i18n="contribute.page.content.starter-issues.header">Starter Issues</a></h2>
             <p data-i18n="[html]contribute.page.content.starter-issues.description">Just getting started? Starter issues are bite-sized bugs that shouldn't take more than an hour or two to complete. They are a great way to learn the codebase <em>and</em> make a difference.</p>
             <div id="starter_issues">
                 <article class="card"><header><h3><a href="https://github.com/adobe/brackets/issues/5479">Unit tests should avoid expect().not.toBeNull() and .not.toBe(null)</a></h3></header><footer><div class="comment-count">4 comment(s)</div></footer></article>

--- a/css/brackets.io.css
+++ b/css/brackets.io.css
@@ -73,6 +73,18 @@ a:active {
     text-decoration: underline;
 }
 
+a.subtle {
+    color: inherit;
+}
+
+a.subtle:hover,a.subtle:focus {
+    border-bottom: 1px dashed rgba(150, 150, 150, .8);
+}
+
+a.subtle:active {
+    border-bottom: none;
+}
+
 .keystroke,
 kbd {
     background-color: #f7f7f7;

--- a/css/brackets.io.css
+++ b/css/brackets.io.css
@@ -73,18 +73,6 @@ a:active {
     text-decoration: underline;
 }
 
-a.subtle {
-    color: inherit;
-}
-
-a.subtle:hover,a.subtle:focus {
-    border-bottom: 1px dashed rgba(150, 150, 150, .8);
-}
-
-a.subtle:active {
-    border-bottom: none;
-}
-
 .keystroke,
 kbd {
     background-color: #f7f7f7;

--- a/css/brackets.io.css
+++ b/css/brackets.io.css
@@ -282,6 +282,18 @@ blockquote p {
     width: 320px;
 }
 
+#download p {
+    width: 370px;
+}
+
+#download p > a {
+    color: #7dfffa;
+    font-size: .7em;
+    font-weight: 600;
+    padding-left: 1.4em;
+    text-shadow: 0 1px 2px rgba(0, 0, 0, 0.2);
+}
+
 .no-bg-img p {
     width: 30em !important;
     max-width: 95% !important;
@@ -313,23 +325,6 @@ blockquote p {
     font-size: 0.7em;
     font-weight: 400;
     margin: 0;
-}
-
-#other-downloads {
-    color: #7dfffa;
-    font-size: .7em;
-    font-weight: 600;
-    padding-left: 1.4em;
-    text-shadow: 0 1px 2px rgba(0, 0, 0, 0.2);
-}
-
-#requirements-link,
-#installation-link {
-    color: #7dfffa;
-    font-size: .7em;
-    font-weight: 600;
-    padding-left: 1.4em;
-    text-shadow: 0 1px 2px rgba(0, 0, 0, 0.2);
 }
 
 #sub-hero-wrapper {

--- a/index.html
+++ b/index.html
@@ -128,8 +128,8 @@ filter: none;
                     </a>
                     <p>
                         <a id="other-downloads" href="http://github.com/adobe/brackets/releases" data-i18n="index.page.hero.other-downloads">Other Downloads</a>
-                        <a id="requirements-link" data-reveal-id="system-requirements" href="#" data-i18n="index.page.hero.requirements">Requirements</a>
-                        <a id="installation-link" data-reveal-id="installation-instructions" href="#" data-i18n="index.page.hero.installation">Installation</a>
+                        <a data-reveal-id="system-requirements" href="#" data-i18n="index.page.hero.requirements">Requirements</a>
+                        <a data-reveal-id="installation-instructions" href="#" data-i18n="index.page.hero.installation">Installation</a>
                     </p>
                 </div>
             </div>
@@ -331,19 +331,6 @@ filter: none;
     <script src="js/nav.js"></script>
     <script>
         $(document).foundation();
-    </script>
-
-    <script>
-        /*
-            $("#requirements-link").click(function() {
-                  //  alert("testing");
-                   // $("#sub-hero-wrapper").empty();
-
-                    $.get( "requirements.inc", function(data) {
-                        $( "#modal" ).html( data );
-                    });
-                });
-            */
     </script>
 
     <script>


### PR DESCRIPTION
This tweaks the stylesheet a bit:
- (HTML) We don't need the `id`s `requirements-link`, `installation-link`, so removing them (and some JS in order to not get uncommented 'cause it won't work any more without the id)
- (CSS) Unify `#requirements-link, #installation-link, #other-downloads` to just one rule
- (CSS) Make the line including these links wider to avoid wrapping
- (HTML) [contribute.html] Make `Starter Issues` a link

@larz0
