### PR TITLE
Prevent update notifications from being cached

### DIFF
--- a/index.html
+++ b/index.html
@@ -374,7 +374,11 @@ filter: none;
             });
         }
 
-        $.getJSON(versionInfoUrl, { "_": new Date().getTime() }, function (data) {
+        $.ajax({
+            dataType: "json",
+            url: versionInfoUrl,
+            cache: false
+        }).done( function (data) {
             i18nLoaded.done(function () {
                 var build = data[0];
                 var buildName = build.versionString;

--- a/index.html
+++ b/index.html
@@ -374,11 +374,11 @@ filter: none;
             });
         }
 
-        $.getJSON(versionInfoUrl, function (data) {
+        $.getJSON(versionInfoUrl, { "_": new Date().getTime() }, function (data) {
             i18nLoaded.done(function () {
                 var build = data[0];
                 var buildName = build.versionString;
-                
+
                 if (buildName) {
                     var buildNum = buildName.match(/([\d.]+)/);
                     if (buildNum) {
@@ -405,7 +405,7 @@ filter: none;
                     // other-download track
                     logAndGo("other-downloads", $("#other-downloads").attr("href"), ['_trackEvent', 'Other-Downloads', buildNum, OS]);
                 }
-                
+
                 // update features (limit 5)
                 var feature_content = "<h2>" + i18n.t("index.page.content.new-features.new-features-in", { defaultValue: "New Features in " + build.versionString, sprintNumber: build.versionString }) + "</h2>";
                 build.newFeatures.slice(0, Math.min(build.newFeatures.length, 5)).forEach(function (feature) {


### PR DESCRIPTION
Added timestamp parameter to ajax request to prevent caching. There are several ways of getting this feature, but this was the one with the least changes and it doesn't really differ from what the generic `$.ajax` call is doing by specifying `{cache: false}` in the request options.
