### PR TITLE
Tuts+ link: Fixes & translation

### DIFF
--- a/contribute.html
+++ b/contribute.html
@@ -329,6 +329,9 @@
                     <li>
                         <a href="http://youtu.be/T6d5C3rLeFY" data-i18n="footer.videos.content.theseus" data-yt-id="T6d5C3rLeFY">JavaScript Debugger for Brackets</a>
                     </li>
+                    <li>
+                        <a href="http://tutsplus.com/courses/introduction-to-brackets?utm_source=Bracketsio&utm_medium=website&utm_campaign=BracketsWebsite" data-i18n="footer.videos.content.tutsplus">Tuts+ Introduction to Brackets</a>
+                    </li>
                 </ul>
 
             </div>

--- a/index.html
+++ b/index.html
@@ -249,8 +249,8 @@ filter: none;
                     <li>
                         <a href="http://youtu.be/T6d5C3rLeFY" data-i18n="footer.videos.content.theseus" data-yt-id="T6d5C3rLeFY">JavaScript Debugger for Brackets</a>
                     </li>
-<li>
-                        <a href="https://courses.tutsplus.com/courses/introduction-to-brackets?utm_source=Bracketsio&utm_medium=website&utm_campaign=BracketsWebsite" data-i18n="footer.videos.content.theseus" data-yt-id="T6d5C3rLeFY">Tuts+ Introduction to Brackets</a>
+                    <li>
+                        <a href="http://tutsplus.com/courses/introduction-to-brackets?utm_source=Bracketsio&utm_medium=website&utm_campaign=BracketsWebsite" data-i18n="footer.videos.content.tutsplus">Tuts+ Introduction to Brackets</a>
                     </li>
                 </ul>
 

--- a/locales/_en/translation.json
+++ b/locales/_en/translation.json
@@ -1,5 +1,5 @@
 {
-    "_last.translated": "8abf320c35ea944206fbc05af1d8218de23062fe",
+    "_last.translated": "181e175024b5e9d9b26413bbdd104174c08783ae",
     "lang": "en",
     "index": {
         "head": {
@@ -180,7 +180,8 @@
             "content": {
                 "intro": "Introducing Brackets",
                 "livedev": "Brackets Live Development for HTML",
-                "theseus": "JavaScript Debugger for Brackets"
+                "theseus": "JavaScript Debugger for Brackets",
+                "tutsplus": "Tuts+ Introduction to Brackets"
             }
         },
         "links": {

--- a/locales/de/translation.json
+++ b/locales/de/translation.json
@@ -1,5 +1,5 @@
 {
-    "_last.translated": "8abf320c35ea944206fbc05af1d8218de23062fe",
+    "_last.translated": "181e175024b5e9d9b26413bbdd104174c08783ae",
     "lang": "de",
     "index": {
         "head": {
@@ -180,7 +180,8 @@
             "content": {
                 "intro": "Vorstellung von Brackets",
                 "livedev": "Brackets Live-Vorschau für HTML",
-                "theseus": "JavaScript Debugger für Brackets"
+                "theseus": "JavaScript Debugger für Brackets",
+                "tutsplus": "Tuts+ Einführung in Brackets"
             }
         },
         "links": {


### PR DESCRIPTION
Includes several changes:
- Remove `data-yt-id`, so that the link is actually opened
- Change `data-i18n`
- Fix indentation
- Copy link to contribute.html
- Add English (fake) translation
- Add German translation
- Shorten the link

@ryanstewart 
