### PR TITLE
Fix an issue where blog post titles were double-escaped

### DIFF
--- a/index.html
+++ b/index.html
@@ -525,7 +525,7 @@ filter: none;
                                 dateComponents[6]);
 
                         $blogposts.append('<h3><a href="' + item.permalink + '">' +
-                            $("<div/>").text(item.title).html() +
+                            item.title +
                             '</a></h3><p>' +
                             postingDate.toLocaleDateString(requestedLang, options) +
                             '</p>');


### PR DESCRIPTION
I saw this with the initial blog post for Release 0.44, which had a dash/hyphen in its title.
The title has been escaped by Wordpress, but our site escaped it again.
