### PR TITLE
Add "Learn more" link and fix "d" tag on download button.

### DIFF
--- a/index.html
+++ b/index.html
@@ -142,7 +142,7 @@
                 </svg>
                 <span data-i18n="index.page.content.why.extract-header">Get Code Hints from a PSD</span>
             </h2>
-            <p data-i18n="index.page.content.why.extract">The Extract for Brackets (Preview) extension lets you pull out design information from a PSD including colors, fonts, gradients, and measurement information as clean, minimal CSS via contextual code hints. You can also extract layers as images, use information from the PSD to define preprocessor variables, and easily get dimensions between objects. All in the context of your code. <a href="http://blog.brackets.io/2014/11/04/brackets-1-0-and-extract-for-brackets-preview-now-available/">Learn more...</a></p>
+            <p><span data-i18n="index.page.content.why.extract">The Extract for Brackets (Preview) extension lets you pull out design information from a PSD including colors, fonts, gradients, and measurement information as clean, minimal CSS via contextual code hints. You can also extract layers as images, use information from the PSD to define preprocessor variables, and easily get dimensions between objects. All in the context of your code.</span> <a href="http://blog.brackets.io/2014/11/04/brackets-1-0-and-extract-for-brackets-preview-now-available/">Learn more...</a></p>
             <p id="secondary-download">
                 <a id="e4b-secondary-download" href="https://github.com/adobe/brackets/releases/latest" class="button radius small secondary" data-i18n="index.page.content.why.extract">Download Brackets + Extract (Preview) by Adobe</a>
 <!--                <a href="https://github.com/adobe/brackets/releases/latest" class="link-beside-button">Download Brackets<br>without PSD Support</a>-->

--- a/index.html
+++ b/index.html
@@ -107,7 +107,7 @@
             <h1><span data-i18n="index.page.hero.description">A modern, open source text editor that understands web design.</span></h1>
             <div id="download">
                 <a id="hero-cta-button" href="https://github.com/adobe/brackets/releases/latest" class="large rounded radius button"><div data-i18n="index.page.hero.download">Download Brackets 1.0</div>
-                    <d id="download-version" class="nowrap" data-i18n="index.page.hero.bundle-info">+ Extract (Preview) by Adobe</span>
+                    <span id="download-version" class="nowrap" data-i18n="index.page.hero.bundle-info">+ Extract (Preview) by Adobe</span>
                 </a>
                 <div id="os-alert" class="alert-box radius" data-alert>
                 </div>
@@ -142,7 +142,7 @@
                 </svg>
                 <span data-i18n="index.page.content.why.extract-header">Get Code Hints from a PSD</span>
             </h2>
-            <p data-i18n="index.page.content.why.extract">The Extract for Brackets (Preview) extension lets you pull out design information from a PSD including colors, fonts, gradients, and measurement information as clean, minimal CSS via contextual code hints. You can also extract layers as images, use information from the PSD to define preprocessor variables, and easily get dimensions between objects. All in the context of your code.</p>
+            <p data-i18n="index.page.content.why.extract">The Extract for Brackets (Preview) extension lets you pull out design information from a PSD including colors, fonts, gradients, and measurement information as clean, minimal CSS via contextual code hints. You can also extract layers as images, use information from the PSD to define preprocessor variables, and easily get dimensions between objects. All in the context of your code. <a href="http://blog.brackets.io/2014/11/04/brackets-1-0-and-extract-for-brackets-preview-now-available/">Learn more...</a></p>
             <p id="secondary-download">
                 <a id="e4b-secondary-download" href="https://github.com/adobe/brackets/releases/latest" class="button radius small secondary" data-i18n="index.page.content.why.extract">Download Brackets + Extract (Preview) by Adobe</a>
 <!--                <a href="https://github.com/adobe/brackets/releases/latest" class="link-beside-button">Download Brackets<br>without PSD Support</a>-->


### PR DESCRIPTION
Learn more was Vincent's suggestion and I noticed the `d` tag in the process (it looks like the "+ Extract for Brackets" text in the download button was supposed to be smaller).
