### PR TITLE
Avoid apparent Chrome bug where scroll pos jumps halfway down the page

### DIFF
--- a/index.html
+++ b/index.html
@@ -152,21 +152,21 @@
     <div class="last-row on-white row">
         <div class="medium-4 large-4 columns">
             <div class="float-obj">
-                <object type="image/svg+xml" width="50px" height="50px" data="img/graphics.svg#inline-editor"></object>
+                <img width="50px" height="50px" src="img/graphics.svg#inline-editor">
             </div>
             <h3 data-i18n="index.page.content.feature-highlights.inline-editor.header">Inline Editors</h3>
             <p data-i18n="[html]index.page.content.feature-highlights.inline-editor.content">Instead of jumping between file tabs, Brackets lets you open a window into the code you care about most. Want to work on the CSS that applies to a specific ID? Put your mouse cursor on that ID, push <kbd>Command</kbd> / <kbd>Ctrl+E</kbd> and Brackets will show you all the CSS selectors with that ID in an inline window so you can work on your code side-by-side without any popups.</p>
         </div>
         <div class="medium-4 large-4 columns">
             <div class="float-obj">
-                <object type="image/svg+xml" width="50px" height="50px" data="img/graphics.svg#live-preview"></object>
+                <img width="50px" height="50px" src="img/graphics.svg#live-preview">
             </div>
             <h3 data-i18n="index.page.content.feature-highlights.live-preview.header">Live Preview</h3>
             <p data-i18n="index.page.content.feature-highlights.live-preview.content">Get a real-time connection to your browser. Make changes to CSS and HTML and you'll instantly see those changes on screen. Also see where your CSS selector is being applied in the browser by simply putting your cursor on it. It's the power of a code editor with the convenience of in-browser dev tools.</p>
         </div>
         <div class="medium-4 large-4 columns">
             <div class="float-obj">
-                <object type="image/svg+xml" width="50px" height="50px" data="img/graphics.svg#preprocessors"></object>
+                <img width="50px" height="50px" src="img/graphics.svg#preprocessors">
             </div>
             <h3 data-i18n="index.page.content.feature-highlights.preprocessor.header">Preprocessor Support</h3>
             <p data-i18n="index.page.content.feature-highlights.preprocessor.content">Work with preprocessors in a whole new way. We know how important preprocessors are to your workflow. That’s why we want to make Brackets the best code editor for preprocessors out there. With Brackets you can use Quick Edit and Live Highlight with your LESS and SCSS files which will make working with them easier than ever.


### PR DESCRIPTION
Avoid apparent Chrome bug where scroll pos jumps halfway down the page once these SVG images have loaded. Only happens when using `<object>`, and there's no reason to not use a plain `<img>` instead.
