### PR TITLE
Updating the version number from 1.1 to 1.2.

### DIFF
--- a/index.html
+++ b/index.html
@@ -106,7 +106,7 @@
         <div class="large-12 columns">
             <h1><span data-i18n="index.page.hero.description">A modern, open source text editor that understands web design.</span></h1>
             <div id="download">
-                <a id="hero-cta-button" href="https://github.com/adobe/brackets/releases/latest" class="large rounded radius button"><div data-i18n="[html]index.page.hero.download">Download Brackets <d id="download-brackets-version">1.1</d></div>
+                <a id="hero-cta-button" href="https://github.com/adobe/brackets/releases/latest" class="large rounded radius button"><div data-i18n="[html]index.page.hero.download">Download Brackets <d id="download-brackets-version">1.2</d></div>
                     <span id="download-version" class="nowrap" data-i18n="index.page.hero.bundle-info">+ Extract (Preview) by Adobe</span>
                 </a>
                 <div id="os-alert" class="alert-box radius" data-alert>
@@ -470,6 +470,18 @@
         $.when(ajaxRequest, i18nLoaded).done(function (data) {
             data = data[0]; // get actual data
             var build = data[0];
+            
+            // Temporarily redirect to older releases for Linux agents
+            // as 1.2 is going to get delayed.
+            
+            var isLinux = false;
+            if (OS === "LINUX32" || OS === "LINUX64") {
+                isLinux = true;
+            }
+            
+            if (isLinux) {
+                build = data[1];
+            }
             var buildName = build.versionString;
 
             if (buildName) {
@@ -482,7 +494,12 @@
                 if (OS != "OTHER" && buildNum) {
                     var tag = buildName.toLowerCase().split(" ").join("-"),
                         url = "https://github.com/adobe/brackets/releases/" + tag,
+                        urlE4B = "https://github.com/adobe/brackets/releases/download/release-1.2%2Beb4/Brackets.1.2.Extract" + ext;
+                    
+                    if (isLinux) {
                         urlE4B = "https://github.com/adobe/brackets/releases/download/release-1.1%2Beb4/Brackets.1.1.Extract" + ext;
+                    }
+                    
                     if (ext) {
                         url = "https://github.com/adobe/brackets/releases/download/" + tag + "/Brackets." + buildName.split(" ").join(".") + ext;
                     }


### PR DESCRIPTION
Note: When brackets.io is opened in Linux we are redirecting them to older releases as the 1.2 release is going to be delayed.
