### PR TITLE
Allow specific (5-char) locale codes

### DIFF
--- a/js/load.i18next.js
+++ b/js/load.i18next.js
@@ -7,7 +7,6 @@ var requestedLang,
         debug: !production, // development only
         detectLngQS: "lang", // use ?lang=... instead of ?setLng=...
         cookieName: "lang", // use cookie "lang" instead of "i18next"
-        load: "unspecific", // only use the unspecific locale ("de" instead of "de-DE")
         useLocalStorage: !!production, // production only
         localStorageExpirationTime: 3 * 24 * 60 * 60 * 1000 // cache 3 days
     },

--- a/locales/README.md
+++ b/locales/README.md
@@ -1,7 +1,7 @@
 # How to add translations for a *new* locale
 
 1. Create a subfolder of the `locales` folder whose name is the language or locale you want to
-   create a translation for. Just use its two-letter code (e.g. `en`, `de`).
+   create a translation for. Just use its two-letter or five-letter code (e.g. `en`, `de`, `pt-BR`).
 2. Edit `load.i18next.js`'s first line and set `var production = false`.
 3. Copy `locales/_en/translation.json` into your subfolder and start translating! The first step is
    easy, just change the `lang` key to the language you are translating (which is equal to the


### PR DESCRIPTION
To prepare for new locales like `pt-BR`.
