### PR TITLE
Improve social media appearance & loading speed on mobile

### DIFF
--- a/index.html
+++ b/index.html
@@ -127,7 +127,10 @@
                     <a id="download-plain-brackets" class="nobr" href="#" data-i18n="index.page.hero.non-bundle-download">Download Brackets without Extract</a>
                     <a id="other-downloads" class="nobr" href="https://github.com/adobe/brackets/releases" data-i18n="index.page.hero.other-downloads">Other Downloads</a>
                 </p>
-                <img src="img/hero.png" srcset="img/hero@2x.png 2x" alt="Screenshot of Brackets">
+                <!--
+                This <img> tag will be added when NOT on mobile
+                <img src="img/hero.png" srcset="img/hero@2x.png 2x" height="370" width="1059" alt="Screenshot of Brackets">
+                -->
             </div>
         </div>
     </div>
@@ -362,6 +365,8 @@
         OS = "OTHER";
         $("#download").hide();
         $("#secondary-download").hide();
+    } else {
+        $("<img src='img/hero.png' srcset='img/hero@2x.png 2x' height='370' width='1059' alt='Screenshot of Brackets'>").appendTo("#download");
     }
 </script>
 

--- a/index.html
+++ b/index.html
@@ -39,8 +39,19 @@
     <link rel="shortcut icon" href="favicon.ico" />
 
     <!-- social media images -->
-    <link rel="image_src" href="/img/hero.png" />
-    <meta property="og:image" content="http://www.brackets.io/img/hero.png" />
+    <!-- Facebook: https://developers.facebook.com/docs/sharing/webmasters#markup -->
+    <meta property="og:url" content="http://brackets.io" />
+    <meta property="og:title" content="A modern, open source code editor that understands web design" />
+    <meta property="og:description" content="Brackets is a lightweight, yet powerful, modern text editor. We blend visual tools into the editor so you get the right amount of help when you want it. With new features and extensions released every 3-4 weeks, it's like getting presents all year long." />
+    <meta property="og:site_name" content="Brackets" />
+    <meta property="og:image" content="http://brackets.io/img/hero@2x.png" />
+    <!-- Twitter Cards: https://dev.twitter.com/cards/overview -->
+    <meta name="twitter:card" content="summary_large_image">
+    <meta name="twitter:site" content="@brackets">
+    <meta name="twitter:creator" content="@brackets">
+    <meta name="twitter:title" content="Brackets - A modern code editor that understands web design">
+    <meta name="twitter:description" content="Brackets is a lightweight, yet powerful, modern text editor. We blend visual tools into the editor so you get the right amount of help when you want it. With new features and extensions released every 3-4 weeks, it's like getting presents all year long.">
+    <meta name="twitter:image" content="http://brackets.io/img/hero@2x.png">
 
     <!-- Only Edit brackets.io.css -->
     <link rel="stylesheet" href="css/brackets.io.css" />


### PR DESCRIPTION
This improves:
- our social media appearance:
  - on Facebook:  
    ![image](https://cloud.githubusercontent.com/assets/2641501/7903144/83817cc6-07d3-11e5-8238-4a12c6222e09.png)  
    (yeah, honestly, we could provide another image that fits their 1:1.91 ratio)
  - on Twitter (new):
    ![image](https://cloud.githubusercontent.com/assets/2641501/7903160/e0137c8c-07d3-11e5-88ce-6a9f90d88f86.png)
- our loading time on mobile, by only loading the hero image when we need (not on Android and iDevices as we don't show it either way)

Currently, it's only for `index.html`, but we can easily extend this PR to also include `contribute.html`.

cc @ryanstewart 
