### PR TITLE
added index.js and inserted script tag for it in all docs pages

### DIFF
--- a/docs/current/assets/css/main.css
+++ b/docs/current/assets/css/main.css
@@ -1,4 +1,4 @@
-/* bootstrap.css override 
+/* bootstrap.css override
 ---------------------------------------------------------*/
 
 body {
@@ -24,7 +24,7 @@ a:focus {
     outline: none;
       -webkit-box-shadow: inset 0 1px 1px rgba(0, 0, 0, 0.075), 0 0 0 2px #6fb5f1;
      -moz-box-shadow: inset 0 1px 1px rgba(0, 0, 0, 0.075), 0 0 0 2px #6fb5f1;
-          box-shadow: inset 0 1px 1px rgba(0, 0, 0, 0.075), 0 0 0 2px #6fb5f1; 
+          box-shadow: inset 0 1px 1px rgba(0, 0, 0, 0.075), 0 0 0 2px #6fb5f1;
 }
 
 p {
@@ -121,7 +121,7 @@ dt {
   color: #000;
   font-weight: 400;
   margin-bottom: 5px;
-  -webkit-font-smoothing: subpixel-antialiased; /* this makes it slightly bolder */    
+  -webkit-font-smoothing: subpixel-antialiased; /* this makes it slightly bolder */
 }
 
 dd {
@@ -153,7 +153,7 @@ textarea {
   -webkit-border-radius: 3px;
      -moz-border-radius: 3px;
           border-radius: 3px;
-          
+
   -webkit-box-shadow: none;
      -moz-box-shadow: none;
           box-shadow: none;
@@ -423,10 +423,10 @@ input[type="color"]:focus,
     background-image: none;
     background: #fff;
     border-bottom: 1px solid rgba(0, 0, 0, 0.12);
-    
+
   -webkit-box-shadow: 0 1px 6px rgba(0, 0, 0, 0.06);
      -moz-box-shadow: 0 1px 6px rgba(0, 0, 0, 0.06);
-          box-shadow: 0 1px 6px rgba(0, 0, 0, 0.06);    
+          box-shadow: 0 1px 6px rgba(0, 0, 0, 0.06);
 }
 
 .navbar-inverse .brand,
@@ -539,9 +539,9 @@ badge {
     padding: 19px 19px 0;
 }
 
-    
 
-    
+
+
 /* non-bootstrap css
 ---------------------------------------------------------*/
 
@@ -731,6 +731,8 @@ h3 .checkbox{
 }
 
 .tt-dropdown-menu {
+  left: auto !important;
+  right: 0 !important;
   min-width: 160px;
   margin-top: 0;
   padding: 5px 0;
@@ -743,7 +745,7 @@ h3 .checkbox{
           border-radius: 4px;
   -webkit-box-shadow: 0 1px 6px rgba(0, 0, 0, 0.12);
      -moz-box-shadow: 0 1px 6px rgba(0, 0, 0, 0.12);
-          box-shadow: 0 1px 6px rgba(0, 0, 0, 0.12); 
+          box-shadow: 0 1px 6px rgba(0, 0, 0, 0.12);
   -webkit-background-clip: padding-box;
      -moz-background-clip: padding;
           background-clip: padding-box;

--- a/docs/current/assets/css/main.css
+++ b/docs/current/assets/css/main.css
@@ -20,7 +20,7 @@ a {
   color: #137cd4;
 }
 
-a:focus {
+.lnsel {
     outline: none;
       -webkit-box-shadow: inset 0 1px 1px rgba(0, 0, 0, 0.075), 0 0 0 2px #6fb5f1;
      -moz-box-shadow: inset 0 1px 1px rgba(0, 0, 0, 0.075), 0 0 0 2px #6fb5f1;
@@ -372,6 +372,7 @@ input[type="color"]:focus,
           box-shadow: inset 0 1px 1px rgba(0, 0, 0, 0.075), 0 0 0 1px #94ceff;
 }
 
+.lnsel,
 .nav > li > a:hover,
 .nav > li > a:focus {
   background-color: #e0f0fa;

--- a/docs/current/assets/css/main.css
+++ b/docs/current/assets/css/main.css
@@ -400,6 +400,11 @@ input[type="color"]:focus,
     text-shadow: none;
 }
 
+.nav-list > li > a {
+  margin-left: -10px;
+  margin-right: -10px;
+}
+
 .nav-header a,
 .nav-header a:hover {
     color: #000 !important;

--- a/docs/current/assets/js/index.js
+++ b/docs/current/assets/js/index.js
@@ -11,8 +11,6 @@ $(function () {
     if (location.hash === "") {
         var hash = location.href.slice(location.href.lastIndexOf("/") + 1, location.href.length - 5);
 
-        $(".span3 a:contains(" + hash + ")").attr("class", "lnsel");
-
         if (hash !== "brackets") {
             location.hash = hash;
         }

--- a/docs/current/assets/js/index.js
+++ b/docs/current/assets/js/index.js
@@ -9,7 +9,7 @@ $(function () {
 
     // Make search results and dependency links go to correct location in left nav
     if (location.hash === "") {
-        var hash = location.href.slice(location.href.lastIndexOf('/') + 1, location.href.length - 5);
+        var hash = location.href.slice(location.href.lastIndexOf("/") + 1, location.href.length - 5);
         if (hash !== "brackets") {
             location.hash = hash;
         }
@@ -55,7 +55,7 @@ $(function () {
                 // when clicked they load new content on right side
                 $(this).click(function () {
                     $.get(href, function (data) {
-                        var pre = $(data).find('.span9');
+                        var pre = $(data).find(".span9");
 
                         // Adjust anchor icons' href to match page they link to
                         $(".anchor", pre).each(function () {
@@ -68,12 +68,15 @@ $(function () {
                         // Remove right side content and add modified
                         $(".span9").empty().append(pre.html());
 
+                        // Set scrollbar to top of the content div
+                        $(".span9").scrollTop(0);
+
                         // Convert dependency relative path links to absolute
                         $(".span9 li a").each(function () {
                             var depHref;
 
                             depHref = $(this).attr("href");
-                            depHref = depHref.slice(depHref.lastIndexOf('./') + 2);
+                            depHref = depHref.slice(depHref.lastIndexOf("./") + 2);
 
                             $(this).attr("href", "http://brackets.io/docs/current/" + depHref);
                         });

--- a/docs/current/assets/js/index.js
+++ b/docs/current/assets/js/index.js
@@ -10,6 +10,9 @@ $(function () {
     // Make search results and dependency links go to correct location in left nav
     if (location.hash === "") {
         var hash = location.href.slice(location.href.lastIndexOf("/") + 1, location.href.length - 5);
+
+        $(".span3 a:contains(" + hash + ")").attr("class", "lnsel");
+
         if (hash !== "brackets") {
             location.hash = hash;
         }

--- a/docs/current/assets/js/index.js
+++ b/docs/current/assets/js/index.js
@@ -1,0 +1,90 @@
+/**
+ *  All code in the function resetListeners() is from apify
+ *
+ *  github page - https://github.com/jbalsas/apify
+ */
+
+$(function () {
+    "use strict";
+
+    // Make search results and dependency links go to correct location in left nav
+    if (location.hash === "") {
+        var hash = location.href.slice(location.href.lastIndexOf('/') + 1, location.href.length - 5);
+        if (hash !== "brackets") {
+            location.hash = hash;
+        }
+    }
+
+    // From main.js
+    function resetListeners() {
+        $(".show-code").click(function () {
+            var block = $(this).parent().find('pre[class*="language-"]');
+            block.toggle();
+            if (block.is(":visible")) {
+                $(this).html("Hide code");
+            } else {
+                $(this).html("Show code");
+            }
+        });
+
+        $("input.toggle-public").click(function () {
+            var section = $(this).parents("section:eq(0)");
+            if ($(this).is(":checked")) {
+                section.addClass("show-private");
+            } else {
+                section.removeClass("show-private");
+            }
+        });
+    }
+
+    // Set left nav links to #, ids to match nav text
+    // and add click listeners to load/insert the requested page
+    function adjustLinks() {
+        $(".span3 a").each(function () {
+            var href = $(this).attr("href");
+
+            if (href !== "javascript:;") {
+                $(this).attr("href", "#");
+
+                // Add ids to links on left side nav
+                if ($(this).text() !== "dependencies") {
+                    $(this).attr("id", $(this).text());
+                }
+
+                // Add click listeners to left side nav links
+                // when clicked they load new content on right side
+                $(this).click(function () {
+                    $.get(href, function (data) {
+                        var pre = $(data).find('.span9');
+
+                        // Adjust anchor icons' href to match page they link to
+                        $(".anchor", pre).each(function () {
+                            var anchorHref;
+
+                            anchorHref = $(this).attr("href");
+                            $(this).attr("href", href + anchorHref);
+                        });
+
+                        // Remove right side content and add modified
+                        $(".span9").empty().append(pre.html());
+
+                        // Convert dependency relative path links to absolute
+                        $(".span9 li a").each(function () {
+                            var depHref;
+
+                            depHref = $(this).attr("href");
+                            depHref = depHref.slice(depHref.lastIndexOf('./') + 2);
+
+                            $(this).attr("href", "http://brackets.io/docs/current/" + depHref);
+                        });
+
+                        // After loading/inserting the content reset/attach new listeners
+                        resetListeners();
+                    });
+                });
+            }
+        });
+    }
+
+    adjustLinks();
+});

--- a/docs/current/assets/js/index.js
+++ b/docs/current/assets/js/index.js
@@ -54,6 +54,11 @@ $(function () {
                 // Add click listeners to left side nav links
                 // when clicked they load new content on right side
                 $(this).click(function () {
+
+                    // Set class of left nav selected to lnsel
+                    $(".lnsel").removeAttr("class");
+                    $(this).attr("class", "lnsel");
+
                     $.get(href, function (data) {
                         var pre = $(data).find(".span9");
 

--- a/docs/current/assets/js/index.js
+++ b/docs/current/assets/js/index.js
@@ -46,6 +46,11 @@ $(function () {
         $(".span3 a").each(function () {
             var href = $(this).attr("href");
 
+            // Adjust link for context menu
+            $(this).on("contextmenu", function () {
+                $(this).attr("href", href);
+            });
+
             if (href !== "javascript:;") {
                 $(this).attr("href", "#");
 

--- a/docs/current/modules/LiveDevelopment/Agents/CSSAgent.html
+++ b/docs/current/modules/LiveDevelopment/Agents/CSSAgent.html
@@ -14,6 +14,7 @@
     <script type="text/javascript" src="../../../assets/js/bootstrap.js"></script>
     <script type="text/javascript" src="../../../assets/js/typeahead.js"></script>
     <script type="text/javascript" src="../../../assets/js/main.js"></script>
+    <script type="text/javascript" src="../../../assets/js/index.js"></script>
     <script src="http://use.edgefonts.net/source-sans-pro:n3,i3,n4,i4;source-code-pro.js"></script>
 
     <!-- Control the Flash of Unstyled Text (or FOUT) -->

--- a/docs/current/modules/LiveDevelopment/Agents/ConsoleAgent.html
+++ b/docs/current/modules/LiveDevelopment/Agents/ConsoleAgent.html
@@ -14,6 +14,7 @@
     <script type="text/javascript" src="../../../assets/js/bootstrap.js"></script>
     <script type="text/javascript" src="../../../assets/js/typeahead.js"></script>
     <script type="text/javascript" src="../../../assets/js/main.js"></script>
+    <script type="text/javascript" src="../../../assets/js/index.js"></script>
     <script src="http://use.edgefonts.net/source-sans-pro:n3,i3,n4,i4;source-code-pro.js"></script>
 
     <!-- Control the Flash of Unstyled Text (or FOUT) -->

--- a/docs/current/modules/LiveDevelopment/Agents/DOMAgent.html
+++ b/docs/current/modules/LiveDevelopment/Agents/DOMAgent.html
@@ -14,6 +14,7 @@
     <script type="text/javascript" src="../../../assets/js/bootstrap.js"></script>
     <script type="text/javascript" src="../../../assets/js/typeahead.js"></script>
     <script type="text/javascript" src="../../../assets/js/main.js"></script>
+    <script type="text/javascript" src="../../../assets/js/index.js"></script>
     <script src="http://use.edgefonts.net/source-sans-pro:n3,i3,n4,i4;source-code-pro.js"></script>
 
     <!-- Control the Flash of Unstyled Text (or FOUT) -->

--- a/docs/current/modules/LiveDevelopment/Agents/DOMHelpers.html
+++ b/docs/current/modules/LiveDevelopment/Agents/DOMHelpers.html
@@ -14,6 +14,7 @@
     <script type="text/javascript" src="../../../assets/js/bootstrap.js"></script>
     <script type="text/javascript" src="../../../assets/js/typeahead.js"></script>
     <script type="text/javascript" src="../../../assets/js/main.js"></script>
+    <script type="text/javascript" src="../../../assets/js/index.js"></script>
     <script src="http://use.edgefonts.net/source-sans-pro:n3,i3,n4,i4;source-code-pro.js"></script>
 
     <!-- Control the Flash of Unstyled Text (or FOUT) -->

--- a/docs/current/modules/LiveDevelopment/Agents/DOMNode.html
+++ b/docs/current/modules/LiveDevelopment/Agents/DOMNode.html
@@ -14,6 +14,7 @@
     <script type="text/javascript" src="../../../assets/js/bootstrap.js"></script>
     <script type="text/javascript" src="../../../assets/js/typeahead.js"></script>
     <script type="text/javascript" src="../../../assets/js/main.js"></script>
+    <script type="text/javascript" src="../../../assets/js/index.js"></script>
     <script src="http://use.edgefonts.net/source-sans-pro:n3,i3,n4,i4;source-code-pro.js"></script>
 
     <!-- Control the Flash of Unstyled Text (or FOUT) -->

--- a/docs/current/modules/LiveDevelopment/Agents/EditAgent.html
+++ b/docs/current/modules/LiveDevelopment/Agents/EditAgent.html
@@ -14,6 +14,7 @@
     <script type="text/javascript" src="../../../assets/js/bootstrap.js"></script>
     <script type="text/javascript" src="../../../assets/js/typeahead.js"></script>
     <script type="text/javascript" src="../../../assets/js/main.js"></script>
+    <script type="text/javascript" src="../../../assets/js/index.js"></script>
     <script src="http://use.edgefonts.net/source-sans-pro:n3,i3,n4,i4;source-code-pro.js"></script>
 
     <!-- Control the Flash of Unstyled Text (or FOUT) -->

--- a/docs/current/modules/LiveDevelopment/Agents/GotoAgent.html
+++ b/docs/current/modules/LiveDevelopment/Agents/GotoAgent.html
@@ -14,6 +14,7 @@
     <script type="text/javascript" src="../../../assets/js/bootstrap.js"></script>
     <script type="text/javascript" src="../../../assets/js/typeahead.js"></script>
     <script type="text/javascript" src="../../../assets/js/main.js"></script>
+    <script type="text/javascript" src="../../../assets/js/index.js"></script>
     <script src="http://use.edgefonts.net/source-sans-pro:n3,i3,n4,i4;source-code-pro.js"></script>
 
     <!-- Control the Flash of Unstyled Text (or FOUT) -->

--- a/docs/current/modules/LiveDevelopment/Agents/HighlightAgent.html
+++ b/docs/current/modules/LiveDevelopment/Agents/HighlightAgent.html
@@ -14,6 +14,7 @@
     <script type="text/javascript" src="../../../assets/js/bootstrap.js"></script>
     <script type="text/javascript" src="../../../assets/js/typeahead.js"></script>
     <script type="text/javascript" src="../../../assets/js/main.js"></script>
+    <script type="text/javascript" src="../../../assets/js/index.js"></script>
     <script src="http://use.edgefonts.net/source-sans-pro:n3,i3,n4,i4;source-code-pro.js"></script>
 
     <!-- Control the Flash of Unstyled Text (or FOUT) -->

--- a/docs/current/modules/LiveDevelopment/Agents/NetworkAgent.html
+++ b/docs/current/modules/LiveDevelopment/Agents/NetworkAgent.html
@@ -14,6 +14,7 @@
     <script type="text/javascript" src="../../../assets/js/bootstrap.js"></script>
     <script type="text/javascript" src="../../../assets/js/typeahead.js"></script>
     <script type="text/javascript" src="../../../assets/js/main.js"></script>
+    <script type="text/javascript" src="../../../assets/js/index.js"></script>
     <script src="http://use.edgefonts.net/source-sans-pro:n3,i3,n4,i4;source-code-pro.js"></script>
 
     <!-- Control the Flash of Unstyled Text (or FOUT) -->

--- a/docs/current/modules/LiveDevelopment/Agents/RemoteAgent.html
+++ b/docs/current/modules/LiveDevelopment/Agents/RemoteAgent.html
@@ -14,6 +14,7 @@
     <script type="text/javascript" src="../../../assets/js/bootstrap.js"></script>
     <script type="text/javascript" src="../../../assets/js/typeahead.js"></script>
     <script type="text/javascript" src="../../../assets/js/main.js"></script>
+    <script type="text/javascript" src="../../../assets/js/index.js"></script>
     <script src="http://use.edgefonts.net/source-sans-pro:n3,i3,n4,i4;source-code-pro.js"></script>
 
     <!-- Control the Flash of Unstyled Text (or FOUT) -->

--- a/docs/current/modules/LiveDevelopment/Agents/RemoteFunctions.html
+++ b/docs/current/modules/LiveDevelopment/Agents/RemoteFunctions.html
@@ -14,6 +14,7 @@
     <script type="text/javascript" src="../../../assets/js/bootstrap.js"></script>
     <script type="text/javascript" src="../../../assets/js/typeahead.js"></script>
     <script type="text/javascript" src="../../../assets/js/main.js"></script>
+    <script type="text/javascript" src="../../../assets/js/index.js"></script>
     <script src="http://use.edgefonts.net/source-sans-pro:n3,i3,n4,i4;source-code-pro.js"></script>
 
     <!-- Control the Flash of Unstyled Text (or FOUT) -->

--- a/docs/current/modules/LiveDevelopment/Agents/ScriptAgent.html
+++ b/docs/current/modules/LiveDevelopment/Agents/ScriptAgent.html
@@ -14,6 +14,7 @@
     <script type="text/javascript" src="../../../assets/js/bootstrap.js"></script>
     <script type="text/javascript" src="../../../assets/js/typeahead.js"></script>
     <script type="text/javascript" src="../../../assets/js/main.js"></script>
+    <script type="text/javascript" src="../../../assets/js/index.js"></script>
     <script src="http://use.edgefonts.net/source-sans-pro:n3,i3,n4,i4;source-code-pro.js"></script>
 
     <!-- Control the Flash of Unstyled Text (or FOUT) -->

--- a/docs/current/modules/LiveDevelopment/Documents/CSSDocument.html
+++ b/docs/current/modules/LiveDevelopment/Documents/CSSDocument.html
@@ -14,6 +14,7 @@
     <script type="text/javascript" src="../../../assets/js/bootstrap.js"></script>
     <script type="text/javascript" src="../../../assets/js/typeahead.js"></script>
     <script type="text/javascript" src="../../../assets/js/main.js"></script>
+    <script type="text/javascript" src="../../../assets/js/index.js"></script>
     <script src="http://use.edgefonts.net/source-sans-pro:n3,i3,n4,i4;source-code-pro.js"></script>
 
     <!-- Control the Flash of Unstyled Text (or FOUT) -->

--- a/docs/current/modules/LiveDevelopment/Documents/CSSPreprocessorDocument.html
+++ b/docs/current/modules/LiveDevelopment/Documents/CSSPreprocessorDocument.html
@@ -14,6 +14,7 @@
     <script type="text/javascript" src="../../../assets/js/bootstrap.js"></script>
     <script type="text/javascript" src="../../../assets/js/typeahead.js"></script>
     <script type="text/javascript" src="../../../assets/js/main.js"></script>
+    <script type="text/javascript" src="../../../assets/js/index.js"></script>
     <script src="http://use.edgefonts.net/source-sans-pro:n3,i3,n4,i4;source-code-pro.js"></script>
 
     <!-- Control the Flash of Unstyled Text (or FOUT) -->

--- a/docs/current/modules/LiveDevelopment/Documents/HTMLDocument.html
+++ b/docs/current/modules/LiveDevelopment/Documents/HTMLDocument.html
@@ -14,6 +14,7 @@
     <script type="text/javascript" src="../../../assets/js/bootstrap.js"></script>
     <script type="text/javascript" src="../../../assets/js/typeahead.js"></script>
     <script type="text/javascript" src="../../../assets/js/main.js"></script>
+    <script type="text/javascript" src="../../../assets/js/index.js"></script>
     <script src="http://use.edgefonts.net/source-sans-pro:n3,i3,n4,i4;source-code-pro.js"></script>
 
     <!-- Control the Flash of Unstyled Text (or FOUT) -->

--- a/docs/current/modules/LiveDevelopment/Documents/JSDocument.html
+++ b/docs/current/modules/LiveDevelopment/Documents/JSDocument.html
@@ -14,6 +14,7 @@
     <script type="text/javascript" src="../../../assets/js/bootstrap.js"></script>
     <script type="text/javascript" src="../../../assets/js/typeahead.js"></script>
     <script type="text/javascript" src="../../../assets/js/main.js"></script>
+    <script type="text/javascript" src="../../../assets/js/index.js"></script>
     <script src="http://use.edgefonts.net/source-sans-pro:n3,i3,n4,i4;source-code-pro.js"></script>
 
     <!-- Control the Flash of Unstyled Text (or FOUT) -->

--- a/docs/current/modules/LiveDevelopment/Inspector/Inspector.html
+++ b/docs/current/modules/LiveDevelopment/Inspector/Inspector.html
@@ -14,6 +14,7 @@
     <script type="text/javascript" src="../../../assets/js/bootstrap.js"></script>
     <script type="text/javascript" src="../../../assets/js/typeahead.js"></script>
     <script type="text/javascript" src="../../../assets/js/main.js"></script>
+    <script type="text/javascript" src="../../../assets/js/index.js"></script>
     <script src="http://use.edgefonts.net/source-sans-pro:n3,i3,n4,i4;source-code-pro.js"></script>
 
     <!-- Control the Flash of Unstyled Text (or FOUT) -->

--- a/docs/current/modules/LiveDevelopment/LiveDevMultiBrowser.html
+++ b/docs/current/modules/LiveDevelopment/LiveDevMultiBrowser.html
@@ -14,6 +14,7 @@
     <script type="text/javascript" src="../../assets/js/bootstrap.js"></script>
     <script type="text/javascript" src="../../assets/js/typeahead.js"></script>
     <script type="text/javascript" src="../../assets/js/main.js"></script>
+    <script type="text/javascript" src="../../assets/js/index.js"></script>
     <script src="http://use.edgefonts.net/source-sans-pro:n3,i3,n4,i4;source-code-pro.js"></script>
 
     <!-- Control the Flash of Unstyled Text (or FOUT) -->

--- a/docs/current/modules/LiveDevelopment/LiveDevServerManager.html
+++ b/docs/current/modules/LiveDevelopment/LiveDevServerManager.html
@@ -14,6 +14,7 @@
     <script type="text/javascript" src="../../assets/js/bootstrap.js"></script>
     <script type="text/javascript" src="../../assets/js/typeahead.js"></script>
     <script type="text/javascript" src="../../assets/js/main.js"></script>
+    <script type="text/javascript" src="../../assets/js/index.js"></script>
     <script src="http://use.edgefonts.net/source-sans-pro:n3,i3,n4,i4;source-code-pro.js"></script>
 
     <!-- Control the Flash of Unstyled Text (or FOUT) -->

--- a/docs/current/modules/LiveDevelopment/LiveDevelopment.html
+++ b/docs/current/modules/LiveDevelopment/LiveDevelopment.html
@@ -14,6 +14,7 @@
     <script type="text/javascript" src="../../assets/js/bootstrap.js"></script>
     <script type="text/javascript" src="../../assets/js/typeahead.js"></script>
     <script type="text/javascript" src="../../assets/js/main.js"></script>
+    <script type="text/javascript" src="../../assets/js/index.js"></script>
     <script src="http://use.edgefonts.net/source-sans-pro:n3,i3,n4,i4;source-code-pro.js"></script>
 
     <!-- Control the Flash of Unstyled Text (or FOUT) -->

--- a/docs/current/modules/LiveDevelopment/LiveDevelopmentUtils.html
+++ b/docs/current/modules/LiveDevelopment/LiveDevelopmentUtils.html
@@ -14,6 +14,7 @@
     <script type="text/javascript" src="../../assets/js/bootstrap.js"></script>
     <script type="text/javascript" src="../../assets/js/typeahead.js"></script>
     <script type="text/javascript" src="../../assets/js/main.js"></script>
+    <script type="text/javascript" src="../../assets/js/index.js"></script>
     <script src="http://use.edgefonts.net/source-sans-pro:n3,i3,n4,i4;source-code-pro.js"></script>
 
     <!-- Control the Flash of Unstyled Text (or FOUT) -->

--- a/docs/current/modules/LiveDevelopment/MultiBrowserImpl/documents/LiveCSSDocument.html
+++ b/docs/current/modules/LiveDevelopment/MultiBrowserImpl/documents/LiveCSSDocument.html
@@ -14,6 +14,7 @@
     <script type="text/javascript" src="../../../../assets/js/bootstrap.js"></script>
     <script type="text/javascript" src="../../../../assets/js/typeahead.js"></script>
     <script type="text/javascript" src="../../../../assets/js/main.js"></script>
+    <script type="text/javascript" src="../../../../assets/js/index.js"></script>
     <script src="http://use.edgefonts.net/source-sans-pro:n3,i3,n4,i4;source-code-pro.js"></script>
 
     <!-- Control the Flash of Unstyled Text (or FOUT) -->

--- a/docs/current/modules/LiveDevelopment/MultiBrowserImpl/documents/LiveDocument.html
+++ b/docs/current/modules/LiveDevelopment/MultiBrowserImpl/documents/LiveDocument.html
@@ -14,6 +14,7 @@
     <script type="text/javascript" src="../../../../assets/js/bootstrap.js"></script>
     <script type="text/javascript" src="../../../../assets/js/typeahead.js"></script>
     <script type="text/javascript" src="../../../../assets/js/main.js"></script>
+    <script type="text/javascript" src="../../../../assets/js/index.js"></script>
     <script src="http://use.edgefonts.net/source-sans-pro:n3,i3,n4,i4;source-code-pro.js"></script>
 
     <!-- Control the Flash of Unstyled Text (or FOUT) -->

--- a/docs/current/modules/LiveDevelopment/MultiBrowserImpl/documents/LiveHTMLDocument.html
+++ b/docs/current/modules/LiveDevelopment/MultiBrowserImpl/documents/LiveHTMLDocument.html
@@ -14,6 +14,7 @@
     <script type="text/javascript" src="../../../../assets/js/bootstrap.js"></script>
     <script type="text/javascript" src="../../../../assets/js/typeahead.js"></script>
     <script type="text/javascript" src="../../../../assets/js/main.js"></script>
+    <script type="text/javascript" src="../../../../assets/js/index.js"></script>
     <script src="http://use.edgefonts.net/source-sans-pro:n3,i3,n4,i4;source-code-pro.js"></script>
 
     <!-- Control the Flash of Unstyled Text (or FOUT) -->

--- a/docs/current/modules/LiveDevelopment/MultiBrowserImpl/language/HTMLInstrumentation.html
+++ b/docs/current/modules/LiveDevelopment/MultiBrowserImpl/language/HTMLInstrumentation.html
@@ -14,6 +14,7 @@
     <script type="text/javascript" src="../../../../assets/js/bootstrap.js"></script>
     <script type="text/javascript" src="../../../../assets/js/typeahead.js"></script>
     <script type="text/javascript" src="../../../../assets/js/main.js"></script>
+    <script type="text/javascript" src="../../../../assets/js/index.js"></script>
     <script src="http://use.edgefonts.net/source-sans-pro:n3,i3,n4,i4;source-code-pro.js"></script>
 
     <!-- Control the Flash of Unstyled Text (or FOUT) -->

--- a/docs/current/modules/LiveDevelopment/MultiBrowserImpl/language/HTMLSimpleDOM.html
+++ b/docs/current/modules/LiveDevelopment/MultiBrowserImpl/language/HTMLSimpleDOM.html
@@ -14,6 +14,7 @@
     <script type="text/javascript" src="../../../../assets/js/bootstrap.js"></script>
     <script type="text/javascript" src="../../../../assets/js/typeahead.js"></script>
     <script type="text/javascript" src="../../../../assets/js/main.js"></script>
+    <script type="text/javascript" src="../../../../assets/js/index.js"></script>
     <script src="http://use.edgefonts.net/source-sans-pro:n3,i3,n4,i4;source-code-pro.js"></script>
 
     <!-- Control the Flash of Unstyled Text (or FOUT) -->

--- a/docs/current/modules/LiveDevelopment/MultiBrowserImpl/launchers/Launcher.html
+++ b/docs/current/modules/LiveDevelopment/MultiBrowserImpl/launchers/Launcher.html
@@ -14,6 +14,7 @@
     <script type="text/javascript" src="../../../../assets/js/bootstrap.js"></script>
     <script type="text/javascript" src="../../../../assets/js/typeahead.js"></script>
     <script type="text/javascript" src="../../../../assets/js/main.js"></script>
+    <script type="text/javascript" src="../../../../assets/js/index.js"></script>
     <script src="http://use.edgefonts.net/source-sans-pro:n3,i3,n4,i4;source-code-pro.js"></script>
 
     <!-- Control the Flash of Unstyled Text (or FOUT) -->

--- a/docs/current/modules/LiveDevelopment/MultiBrowserImpl/launchers/node/LauncherDomain.html
+++ b/docs/current/modules/LiveDevelopment/MultiBrowserImpl/launchers/node/LauncherDomain.html
@@ -14,6 +14,7 @@
     <script type="text/javascript" src="../../../../../assets/js/bootstrap.js"></script>
     <script type="text/javascript" src="../../../../../assets/js/typeahead.js"></script>
     <script type="text/javascript" src="../../../../../assets/js/main.js"></script>
+    <script type="text/javascript" src="../../../../../assets/js/index.js"></script>
     <script src="http://use.edgefonts.net/source-sans-pro:n3,i3,n4,i4;source-code-pro.js"></script>
 
     <!-- Control the Flash of Unstyled Text (or FOUT) -->

--- a/docs/current/modules/LiveDevelopment/MultiBrowserImpl/protocol/LiveDevProtocol.html
+++ b/docs/current/modules/LiveDevelopment/MultiBrowserImpl/protocol/LiveDevProtocol.html
@@ -14,6 +14,7 @@
     <script type="text/javascript" src="../../../../assets/js/bootstrap.js"></script>
     <script type="text/javascript" src="../../../../assets/js/typeahead.js"></script>
     <script type="text/javascript" src="../../../../assets/js/main.js"></script>
+    <script type="text/javascript" src="../../../../assets/js/index.js"></script>
     <script src="http://use.edgefonts.net/source-sans-pro:n3,i3,n4,i4;source-code-pro.js"></script>
 
     <!-- Control the Flash of Unstyled Text (or FOUT) -->

--- a/docs/current/modules/LiveDevelopment/MultiBrowserImpl/protocol/remote/DocumentObserver.html
+++ b/docs/current/modules/LiveDevelopment/MultiBrowserImpl/protocol/remote/DocumentObserver.html
@@ -14,6 +14,7 @@
     <script type="text/javascript" src="../../../../../assets/js/bootstrap.js"></script>
     <script type="text/javascript" src="../../../../../assets/js/typeahead.js"></script>
     <script type="text/javascript" src="../../../../../assets/js/main.js"></script>
+    <script type="text/javascript" src="../../../../../assets/js/index.js"></script>
     <script src="http://use.edgefonts.net/source-sans-pro:n3,i3,n4,i4;source-code-pro.js"></script>
 
     <!-- Control the Flash of Unstyled Text (or FOUT) -->

--- a/docs/current/modules/LiveDevelopment/MultiBrowserImpl/protocol/remote/LiveDevProtocolRemote.html
+++ b/docs/current/modules/LiveDevelopment/MultiBrowserImpl/protocol/remote/LiveDevProtocolRemote.html
@@ -14,6 +14,7 @@
     <script type="text/javascript" src="../../../../../assets/js/bootstrap.js"></script>
     <script type="text/javascript" src="../../../../../assets/js/typeahead.js"></script>
     <script type="text/javascript" src="../../../../../assets/js/main.js"></script>
+    <script type="text/javascript" src="../../../../../assets/js/index.js"></script>
     <script src="http://use.edgefonts.net/source-sans-pro:n3,i3,n4,i4;source-code-pro.js"></script>
 
     <!-- Control the Flash of Unstyled Text (or FOUT) -->

--- a/docs/current/modules/LiveDevelopment/MultiBrowserImpl/transports/NodeSocketTransport.html
+++ b/docs/current/modules/LiveDevelopment/MultiBrowserImpl/transports/NodeSocketTransport.html
@@ -14,6 +14,7 @@
     <script type="text/javascript" src="../../../../assets/js/bootstrap.js"></script>
     <script type="text/javascript" src="../../../../assets/js/typeahead.js"></script>
     <script type="text/javascript" src="../../../../assets/js/main.js"></script>
+    <script type="text/javascript" src="../../../../assets/js/index.js"></script>
     <script src="http://use.edgefonts.net/source-sans-pro:n3,i3,n4,i4;source-code-pro.js"></script>
 
     <!-- Control the Flash of Unstyled Text (or FOUT) -->

--- a/docs/current/modules/LiveDevelopment/MultiBrowserImpl/transports/node/NodeSocketTransportDomain.html
+++ b/docs/current/modules/LiveDevelopment/MultiBrowserImpl/transports/node/NodeSocketTransportDomain.html
@@ -14,6 +14,7 @@
     <script type="text/javascript" src="../../../../../assets/js/bootstrap.js"></script>
     <script type="text/javascript" src="../../../../../assets/js/typeahead.js"></script>
     <script type="text/javascript" src="../../../../../assets/js/main.js"></script>
+    <script type="text/javascript" src="../../../../../assets/js/index.js"></script>
     <script src="http://use.edgefonts.net/source-sans-pro:n3,i3,n4,i4;source-code-pro.js"></script>
 
     <!-- Control the Flash of Unstyled Text (or FOUT) -->

--- a/docs/current/modules/LiveDevelopment/MultiBrowserImpl/transports/remote/NodeSocketTransportRemote.html
+++ b/docs/current/modules/LiveDevelopment/MultiBrowserImpl/transports/remote/NodeSocketTransportRemote.html
@@ -14,6 +14,7 @@
     <script type="text/javascript" src="../../../../../assets/js/bootstrap.js"></script>
     <script type="text/javascript" src="../../../../../assets/js/typeahead.js"></script>
     <script type="text/javascript" src="../../../../../assets/js/main.js"></script>
+    <script type="text/javascript" src="../../../../../assets/js/index.js"></script>
     <script src="http://use.edgefonts.net/source-sans-pro:n3,i3,n4,i4;source-code-pro.js"></script>
 
     <!-- Control the Flash of Unstyled Text (or FOUT) -->

--- a/docs/current/modules/LiveDevelopment/Servers/BaseServer.html
+++ b/docs/current/modules/LiveDevelopment/Servers/BaseServer.html
@@ -14,6 +14,7 @@
     <script type="text/javascript" src="../../../assets/js/bootstrap.js"></script>
     <script type="text/javascript" src="../../../assets/js/typeahead.js"></script>
     <script type="text/javascript" src="../../../assets/js/main.js"></script>
+    <script type="text/javascript" src="../../../assets/js/index.js"></script>
     <script src="http://use.edgefonts.net/source-sans-pro:n3,i3,n4,i4;source-code-pro.js"></script>
 
     <!-- Control the Flash of Unstyled Text (or FOUT) -->

--- a/docs/current/modules/LiveDevelopment/Servers/FileServer.html
+++ b/docs/current/modules/LiveDevelopment/Servers/FileServer.html
@@ -14,6 +14,7 @@
     <script type="text/javascript" src="../../../assets/js/bootstrap.js"></script>
     <script type="text/javascript" src="../../../assets/js/typeahead.js"></script>
     <script type="text/javascript" src="../../../assets/js/main.js"></script>
+    <script type="text/javascript" src="../../../assets/js/index.js"></script>
     <script src="http://use.edgefonts.net/source-sans-pro:n3,i3,n4,i4;source-code-pro.js"></script>
 
     <!-- Control the Flash of Unstyled Text (or FOUT) -->

--- a/docs/current/modules/LiveDevelopment/Servers/UserServer.html
+++ b/docs/current/modules/LiveDevelopment/Servers/UserServer.html
@@ -14,6 +14,7 @@
     <script type="text/javascript" src="../../../assets/js/bootstrap.js"></script>
     <script type="text/javascript" src="../../../assets/js/typeahead.js"></script>
     <script type="text/javascript" src="../../../assets/js/main.js"></script>
+    <script type="text/javascript" src="../../../assets/js/index.js"></script>
     <script src="http://use.edgefonts.net/source-sans-pro:n3,i3,n4,i4;source-code-pro.js"></script>
 
     <!-- Control the Flash of Unstyled Text (or FOUT) -->

--- a/docs/current/modules/LiveDevelopment/main.html
+++ b/docs/current/modules/LiveDevelopment/main.html
@@ -14,6 +14,7 @@
     <script type="text/javascript" src="../../assets/js/bootstrap.js"></script>
     <script type="text/javascript" src="../../assets/js/typeahead.js"></script>
     <script type="text/javascript" src="../../assets/js/main.js"></script>
+    <script type="text/javascript" src="../../assets/js/index.js"></script>
     <script src="http://use.edgefonts.net/source-sans-pro:n3,i3,n4,i4;source-code-pro.js"></script>
 
     <!-- Control the Flash of Unstyled Text (or FOUT) -->

--- a/docs/current/modules/brackets.html
+++ b/docs/current/modules/brackets.html
@@ -14,6 +14,7 @@
     <script type="text/javascript" src="../assets/js/bootstrap.js"></script>
     <script type="text/javascript" src="../assets/js/typeahead.js"></script>
     <script type="text/javascript" src="../assets/js/main.js"></script>
+    <script type="text/javascript" src="../assets/js/index.js"></script>
     <script src="http://use.edgefonts.net/source-sans-pro:n3,i3,n4,i4;source-code-pro.js"></script>
 
     <!-- Control the Flash of Unstyled Text (or FOUT) -->

--- a/docs/current/modules/command/CommandManager.html
+++ b/docs/current/modules/command/CommandManager.html
@@ -14,6 +14,7 @@
     <script type="text/javascript" src="../../assets/js/bootstrap.js"></script>
     <script type="text/javascript" src="../../assets/js/typeahead.js"></script>
     <script type="text/javascript" src="../../assets/js/main.js"></script>
+    <script type="text/javascript" src="../../assets/js/index.js"></script>
     <script src="http://use.edgefonts.net/source-sans-pro:n3,i3,n4,i4;source-code-pro.js"></script>
 
     <!-- Control the Flash of Unstyled Text (or FOUT) -->

--- a/docs/current/modules/command/Commands.html
+++ b/docs/current/modules/command/Commands.html
@@ -14,6 +14,7 @@
     <script type="text/javascript" src="../../assets/js/bootstrap.js"></script>
     <script type="text/javascript" src="../../assets/js/typeahead.js"></script>
     <script type="text/javascript" src="../../assets/js/main.js"></script>
+    <script type="text/javascript" src="../../assets/js/index.js"></script>
     <script src="http://use.edgefonts.net/source-sans-pro:n3,i3,n4,i4;source-code-pro.js"></script>
 
     <!-- Control the Flash of Unstyled Text (or FOUT) -->

--- a/docs/current/modules/command/DefaultMenus.html
+++ b/docs/current/modules/command/DefaultMenus.html
@@ -14,6 +14,7 @@
     <script type="text/javascript" src="../../assets/js/bootstrap.js"></script>
     <script type="text/javascript" src="../../assets/js/typeahead.js"></script>
     <script type="text/javascript" src="../../assets/js/main.js"></script>
+    <script type="text/javascript" src="../../assets/js/index.js"></script>
     <script src="http://use.edgefonts.net/source-sans-pro:n3,i3,n4,i4;source-code-pro.js"></script>
 
     <!-- Control the Flash of Unstyled Text (or FOUT) -->

--- a/docs/current/modules/command/KeyBindingManager.html
+++ b/docs/current/modules/command/KeyBindingManager.html
@@ -14,6 +14,7 @@
     <script type="text/javascript" src="../../assets/js/bootstrap.js"></script>
     <script type="text/javascript" src="../../assets/js/typeahead.js"></script>
     <script type="text/javascript" src="../../assets/js/main.js"></script>
+    <script type="text/javascript" src="../../assets/js/index.js"></script>
     <script src="http://use.edgefonts.net/source-sans-pro:n3,i3,n4,i4;source-code-pro.js"></script>
 
     <!-- Control the Flash of Unstyled Text (or FOUT) -->

--- a/docs/current/modules/command/Menus.html
+++ b/docs/current/modules/command/Menus.html
@@ -14,6 +14,7 @@
     <script type="text/javascript" src="../../assets/js/bootstrap.js"></script>
     <script type="text/javascript" src="../../assets/js/typeahead.js"></script>
     <script type="text/javascript" src="../../assets/js/main.js"></script>
+    <script type="text/javascript" src="../../assets/js/index.js"></script>
     <script src="http://use.edgefonts.net/source-sans-pro:n3,i3,n4,i4;source-code-pro.js"></script>
 
     <!-- Control the Flash of Unstyled Text (or FOUT) -->

--- a/docs/current/modules/dependencies.html
+++ b/docs/current/modules/dependencies.html
@@ -14,6 +14,7 @@
     <script type="text/javascript" src="../assets/js/bootstrap.js"></script>
     <script type="text/javascript" src="../assets/js/typeahead.js"></script>
     <script type="text/javascript" src="../assets/js/main.js"></script>
+    <script type="text/javascript" src="../assets/js/index.js"></script>
     <script src="http://use.edgefonts.net/source-sans-pro:n3,i3,n4,i4;source-code-pro.js"></script>
 
     <!-- Control the Flash of Unstyled Text (or FOUT) -->

--- a/docs/current/modules/document/ChangedDocumentTracker.html
+++ b/docs/current/modules/document/ChangedDocumentTracker.html
@@ -14,6 +14,7 @@
     <script type="text/javascript" src="../../assets/js/bootstrap.js"></script>
     <script type="text/javascript" src="../../assets/js/typeahead.js"></script>
     <script type="text/javascript" src="../../assets/js/main.js"></script>
+    <script type="text/javascript" src="../../assets/js/index.js"></script>
     <script src="http://use.edgefonts.net/source-sans-pro:n3,i3,n4,i4;source-code-pro.js"></script>
 
     <!-- Control the Flash of Unstyled Text (or FOUT) -->

--- a/docs/current/modules/document/Document.html
+++ b/docs/current/modules/document/Document.html
@@ -14,6 +14,7 @@
     <script type="text/javascript" src="../../assets/js/bootstrap.js"></script>
     <script type="text/javascript" src="../../assets/js/typeahead.js"></script>
     <script type="text/javascript" src="../../assets/js/main.js"></script>
+    <script type="text/javascript" src="../../assets/js/index.js"></script>
     <script src="http://use.edgefonts.net/source-sans-pro:n3,i3,n4,i4;source-code-pro.js"></script>
 
     <!-- Control the Flash of Unstyled Text (or FOUT) -->

--- a/docs/current/modules/document/DocumentCommandHandlers.html
+++ b/docs/current/modules/document/DocumentCommandHandlers.html
@@ -14,6 +14,7 @@
     <script type="text/javascript" src="../../assets/js/bootstrap.js"></script>
     <script type="text/javascript" src="../../assets/js/typeahead.js"></script>
     <script type="text/javascript" src="../../assets/js/main.js"></script>
+    <script type="text/javascript" src="../../assets/js/index.js"></script>
     <script src="http://use.edgefonts.net/source-sans-pro:n3,i3,n4,i4;source-code-pro.js"></script>
 
     <!-- Control the Flash of Unstyled Text (or FOUT) -->

--- a/docs/current/modules/document/DocumentManager.html
+++ b/docs/current/modules/document/DocumentManager.html
@@ -14,6 +14,7 @@
     <script type="text/javascript" src="../../assets/js/bootstrap.js"></script>
     <script type="text/javascript" src="../../assets/js/typeahead.js"></script>
     <script type="text/javascript" src="../../assets/js/main.js"></script>
+    <script type="text/javascript" src="../../assets/js/index.js"></script>
     <script src="http://use.edgefonts.net/source-sans-pro:n3,i3,n4,i4;source-code-pro.js"></script>
 
     <!-- Control the Flash of Unstyled Text (or FOUT) -->

--- a/docs/current/modules/document/InMemoryFile.html
+++ b/docs/current/modules/document/InMemoryFile.html
@@ -14,6 +14,7 @@
     <script type="text/javascript" src="../../assets/js/bootstrap.js"></script>
     <script type="text/javascript" src="../../assets/js/typeahead.js"></script>
     <script type="text/javascript" src="../../assets/js/main.js"></script>
+    <script type="text/javascript" src="../../assets/js/index.js"></script>
     <script src="http://use.edgefonts.net/source-sans-pro:n3,i3,n4,i4;source-code-pro.js"></script>
 
     <!-- Control the Flash of Unstyled Text (or FOUT) -->

--- a/docs/current/modules/document/TextRange.html
+++ b/docs/current/modules/document/TextRange.html
@@ -14,6 +14,7 @@
     <script type="text/javascript" src="../../assets/js/bootstrap.js"></script>
     <script type="text/javascript" src="../../assets/js/typeahead.js"></script>
     <script type="text/javascript" src="../../assets/js/main.js"></script>
+    <script type="text/javascript" src="../../assets/js/index.js"></script>
     <script src="http://use.edgefonts.net/source-sans-pro:n3,i3,n4,i4;source-code-pro.js"></script>
 
     <!-- Control the Flash of Unstyled Text (or FOUT) -->

--- a/docs/current/modules/editor/CSSInlineEditor.html
+++ b/docs/current/modules/editor/CSSInlineEditor.html
@@ -14,6 +14,7 @@
     <script type="text/javascript" src="../../assets/js/bootstrap.js"></script>
     <script type="text/javascript" src="../../assets/js/typeahead.js"></script>
     <script type="text/javascript" src="../../assets/js/main.js"></script>
+    <script type="text/javascript" src="../../assets/js/index.js"></script>
     <script src="http://use.edgefonts.net/source-sans-pro:n3,i3,n4,i4;source-code-pro.js"></script>
 
     <!-- Control the Flash of Unstyled Text (or FOUT) -->

--- a/docs/current/modules/editor/CodeHintList.html
+++ b/docs/current/modules/editor/CodeHintList.html
@@ -14,6 +14,7 @@
     <script type="text/javascript" src="../../assets/js/bootstrap.js"></script>
     <script type="text/javascript" src="../../assets/js/typeahead.js"></script>
     <script type="text/javascript" src="../../assets/js/main.js"></script>
+    <script type="text/javascript" src="../../assets/js/index.js"></script>
     <script src="http://use.edgefonts.net/source-sans-pro:n3,i3,n4,i4;source-code-pro.js"></script>
 
     <!-- Control the Flash of Unstyled Text (or FOUT) -->

--- a/docs/current/modules/editor/CodeHintManager.html
+++ b/docs/current/modules/editor/CodeHintManager.html
@@ -14,6 +14,7 @@
     <script type="text/javascript" src="../../assets/js/bootstrap.js"></script>
     <script type="text/javascript" src="../../assets/js/typeahead.js"></script>
     <script type="text/javascript" src="../../assets/js/main.js"></script>
+    <script type="text/javascript" src="../../assets/js/index.js"></script>
     <script src="http://use.edgefonts.net/source-sans-pro:n3,i3,n4,i4;source-code-pro.js"></script>
 
     <!-- Control the Flash of Unstyled Text (or FOUT) -->

--- a/docs/current/modules/editor/Editor.html
+++ b/docs/current/modules/editor/Editor.html
@@ -14,6 +14,7 @@
     <script type="text/javascript" src="../../assets/js/bootstrap.js"></script>
     <script type="text/javascript" src="../../assets/js/typeahead.js"></script>
     <script type="text/javascript" src="../../assets/js/main.js"></script>
+    <script type="text/javascript" src="../../assets/js/index.js"></script>
     <script src="http://use.edgefonts.net/source-sans-pro:n3,i3,n4,i4;source-code-pro.js"></script>
 
     <!-- Control the Flash of Unstyled Text (or FOUT) -->

--- a/docs/current/modules/editor/EditorCommandHandlers.html
+++ b/docs/current/modules/editor/EditorCommandHandlers.html
@@ -14,6 +14,7 @@
     <script type="text/javascript" src="../../assets/js/bootstrap.js"></script>
     <script type="text/javascript" src="../../assets/js/typeahead.js"></script>
     <script type="text/javascript" src="../../assets/js/main.js"></script>
+    <script type="text/javascript" src="../../assets/js/index.js"></script>
     <script src="http://use.edgefonts.net/source-sans-pro:n3,i3,n4,i4;source-code-pro.js"></script>
 
     <!-- Control the Flash of Unstyled Text (or FOUT) -->

--- a/docs/current/modules/editor/EditorManager.html
+++ b/docs/current/modules/editor/EditorManager.html
@@ -14,6 +14,7 @@
     <script type="text/javascript" src="../../assets/js/bootstrap.js"></script>
     <script type="text/javascript" src="../../assets/js/typeahead.js"></script>
     <script type="text/javascript" src="../../assets/js/main.js"></script>
+    <script type="text/javascript" src="../../assets/js/index.js"></script>
     <script src="http://use.edgefonts.net/source-sans-pro:n3,i3,n4,i4;source-code-pro.js"></script>
 
     <!-- Control the Flash of Unstyled Text (or FOUT) -->

--- a/docs/current/modules/editor/EditorOptionHandlers.html
+++ b/docs/current/modules/editor/EditorOptionHandlers.html
@@ -14,6 +14,7 @@
     <script type="text/javascript" src="../../assets/js/bootstrap.js"></script>
     <script type="text/javascript" src="../../assets/js/typeahead.js"></script>
     <script type="text/javascript" src="../../assets/js/main.js"></script>
+    <script type="text/javascript" src="../../assets/js/index.js"></script>
     <script src="http://use.edgefonts.net/source-sans-pro:n3,i3,n4,i4;source-code-pro.js"></script>
 
     <!-- Control the Flash of Unstyled Text (or FOUT) -->

--- a/docs/current/modules/editor/EditorStatusBar.html
+++ b/docs/current/modules/editor/EditorStatusBar.html
@@ -14,6 +14,7 @@
     <script type="text/javascript" src="../../assets/js/bootstrap.js"></script>
     <script type="text/javascript" src="../../assets/js/typeahead.js"></script>
     <script type="text/javascript" src="../../assets/js/main.js"></script>
+    <script type="text/javascript" src="../../assets/js/index.js"></script>
     <script src="http://use.edgefonts.net/source-sans-pro:n3,i3,n4,i4;source-code-pro.js"></script>
 
     <!-- Control the Flash of Unstyled Text (or FOUT) -->

--- a/docs/current/modules/editor/ImageViewer.html
+++ b/docs/current/modules/editor/ImageViewer.html
@@ -14,6 +14,7 @@
     <script type="text/javascript" src="../../assets/js/bootstrap.js"></script>
     <script type="text/javascript" src="../../assets/js/typeahead.js"></script>
     <script type="text/javascript" src="../../assets/js/main.js"></script>
+    <script type="text/javascript" src="../../assets/js/index.js"></script>
     <script src="http://use.edgefonts.net/source-sans-pro:n3,i3,n4,i4;source-code-pro.js"></script>
 
     <!-- Control the Flash of Unstyled Text (or FOUT) -->

--- a/docs/current/modules/editor/InlineTextEditor.html
+++ b/docs/current/modules/editor/InlineTextEditor.html
@@ -14,6 +14,7 @@
     <script type="text/javascript" src="../../assets/js/bootstrap.js"></script>
     <script type="text/javascript" src="../../assets/js/typeahead.js"></script>
     <script type="text/javascript" src="../../assets/js/main.js"></script>
+    <script type="text/javascript" src="../../assets/js/index.js"></script>
     <script src="http://use.edgefonts.net/source-sans-pro:n3,i3,n4,i4;source-code-pro.js"></script>
 
     <!-- Control the Flash of Unstyled Text (or FOUT) -->

--- a/docs/current/modules/editor/InlineWidget.html
+++ b/docs/current/modules/editor/InlineWidget.html
@@ -14,6 +14,7 @@
     <script type="text/javascript" src="../../assets/js/bootstrap.js"></script>
     <script type="text/javascript" src="../../assets/js/typeahead.js"></script>
     <script type="text/javascript" src="../../assets/js/main.js"></script>
+    <script type="text/javascript" src="../../assets/js/index.js"></script>
     <script src="http://use.edgefonts.net/source-sans-pro:n3,i3,n4,i4;source-code-pro.js"></script>
 
     <!-- Control the Flash of Unstyled Text (or FOUT) -->

--- a/docs/current/modules/editor/MultiRangeInlineEditor.html
+++ b/docs/current/modules/editor/MultiRangeInlineEditor.html
@@ -14,6 +14,7 @@
     <script type="text/javascript" src="../../assets/js/bootstrap.js"></script>
     <script type="text/javascript" src="../../assets/js/typeahead.js"></script>
     <script type="text/javascript" src="../../assets/js/main.js"></script>
+    <script type="text/javascript" src="../../assets/js/index.js"></script>
     <script src="http://use.edgefonts.net/source-sans-pro:n3,i3,n4,i4;source-code-pro.js"></script>
 
     <!-- Control the Flash of Unstyled Text (or FOUT) -->

--- a/docs/current/modules/extensibility/ExtensionManager.html
+++ b/docs/current/modules/extensibility/ExtensionManager.html
@@ -14,6 +14,7 @@
     <script type="text/javascript" src="../../assets/js/bootstrap.js"></script>
     <script type="text/javascript" src="../../assets/js/typeahead.js"></script>
     <script type="text/javascript" src="../../assets/js/main.js"></script>
+    <script type="text/javascript" src="../../assets/js/index.js"></script>
     <script src="http://use.edgefonts.net/source-sans-pro:n3,i3,n4,i4;source-code-pro.js"></script>
 
     <!-- Control the Flash of Unstyled Text (or FOUT) -->

--- a/docs/current/modules/extensibility/ExtensionManagerDialog.html
+++ b/docs/current/modules/extensibility/ExtensionManagerDialog.html
@@ -14,6 +14,7 @@
     <script type="text/javascript" src="../../assets/js/bootstrap.js"></script>
     <script type="text/javascript" src="../../assets/js/typeahead.js"></script>
     <script type="text/javascript" src="../../assets/js/main.js"></script>
+    <script type="text/javascript" src="../../assets/js/index.js"></script>
     <script src="http://use.edgefonts.net/source-sans-pro:n3,i3,n4,i4;source-code-pro.js"></script>
 
     <!-- Control the Flash of Unstyled Text (or FOUT) -->

--- a/docs/current/modules/extensibility/ExtensionManagerView.html
+++ b/docs/current/modules/extensibility/ExtensionManagerView.html
@@ -14,6 +14,7 @@
     <script type="text/javascript" src="../../assets/js/bootstrap.js"></script>
     <script type="text/javascript" src="../../assets/js/typeahead.js"></script>
     <script type="text/javascript" src="../../assets/js/main.js"></script>
+    <script type="text/javascript" src="../../assets/js/index.js"></script>
     <script src="http://use.edgefonts.net/source-sans-pro:n3,i3,n4,i4;source-code-pro.js"></script>
 
     <!-- Control the Flash of Unstyled Text (or FOUT) -->

--- a/docs/current/modules/extensibility/ExtensionManagerViewModel.html
+++ b/docs/current/modules/extensibility/ExtensionManagerViewModel.html
@@ -14,6 +14,7 @@
     <script type="text/javascript" src="../../assets/js/bootstrap.js"></script>
     <script type="text/javascript" src="../../assets/js/typeahead.js"></script>
     <script type="text/javascript" src="../../assets/js/main.js"></script>
+    <script type="text/javascript" src="../../assets/js/index.js"></script>
     <script src="http://use.edgefonts.net/source-sans-pro:n3,i3,n4,i4;source-code-pro.js"></script>
 
     <!-- Control the Flash of Unstyled Text (or FOUT) -->

--- a/docs/current/modules/extensibility/InstallExtensionDialog.html
+++ b/docs/current/modules/extensibility/InstallExtensionDialog.html
@@ -14,6 +14,7 @@
     <script type="text/javascript" src="../../assets/js/bootstrap.js"></script>
     <script type="text/javascript" src="../../assets/js/typeahead.js"></script>
     <script type="text/javascript" src="../../assets/js/main.js"></script>
+    <script type="text/javascript" src="../../assets/js/index.js"></script>
     <script src="http://use.edgefonts.net/source-sans-pro:n3,i3,n4,i4;source-code-pro.js"></script>
 
     <!-- Control the Flash of Unstyled Text (or FOUT) -->

--- a/docs/current/modules/extensibility/Package.html
+++ b/docs/current/modules/extensibility/Package.html
@@ -14,6 +14,7 @@
     <script type="text/javascript" src="../../assets/js/bootstrap.js"></script>
     <script type="text/javascript" src="../../assets/js/typeahead.js"></script>
     <script type="text/javascript" src="../../assets/js/main.js"></script>
+    <script type="text/javascript" src="../../assets/js/index.js"></script>
     <script src="http://use.edgefonts.net/source-sans-pro:n3,i3,n4,i4;source-code-pro.js"></script>
 
     <!-- Control the Flash of Unstyled Text (or FOUT) -->

--- a/docs/current/modules/extensibility/registry_utils.html
+++ b/docs/current/modules/extensibility/registry_utils.html
@@ -14,6 +14,7 @@
     <script type="text/javascript" src="../../assets/js/bootstrap.js"></script>
     <script type="text/javascript" src="../../assets/js/typeahead.js"></script>
     <script type="text/javascript" src="../../assets/js/main.js"></script>
+    <script type="text/javascript" src="../../assets/js/index.js"></script>
     <script src="http://use.edgefonts.net/source-sans-pro:n3,i3,n4,i4;source-code-pro.js"></script>
 
     <!-- Control the Flash of Unstyled Text (or FOUT) -->

--- a/docs/current/modules/file/FileUtils.html
+++ b/docs/current/modules/file/FileUtils.html
@@ -14,6 +14,7 @@
     <script type="text/javascript" src="../../assets/js/bootstrap.js"></script>
     <script type="text/javascript" src="../../assets/js/typeahead.js"></script>
     <script type="text/javascript" src="../../assets/js/main.js"></script>
+    <script type="text/javascript" src="../../assets/js/index.js"></script>
     <script src="http://use.edgefonts.net/source-sans-pro:n3,i3,n4,i4;source-code-pro.js"></script>
 
     <!-- Control the Flash of Unstyled Text (or FOUT) -->

--- a/docs/current/modules/file/NativeFileError.html
+++ b/docs/current/modules/file/NativeFileError.html
@@ -14,6 +14,7 @@
     <script type="text/javascript" src="../../assets/js/bootstrap.js"></script>
     <script type="text/javascript" src="../../assets/js/typeahead.js"></script>
     <script type="text/javascript" src="../../assets/js/main.js"></script>
+    <script type="text/javascript" src="../../assets/js/index.js"></script>
     <script src="http://use.edgefonts.net/source-sans-pro:n3,i3,n4,i4;source-code-pro.js"></script>
 
     <!-- Control the Flash of Unstyled Text (or FOUT) -->

--- a/docs/current/modules/file/NativeFileSystem.html
+++ b/docs/current/modules/file/NativeFileSystem.html
@@ -14,6 +14,7 @@
     <script type="text/javascript" src="../../assets/js/bootstrap.js"></script>
     <script type="text/javascript" src="../../assets/js/typeahead.js"></script>
     <script type="text/javascript" src="../../assets/js/main.js"></script>
+    <script type="text/javascript" src="../../assets/js/index.js"></script>
     <script src="http://use.edgefonts.net/source-sans-pro:n3,i3,n4,i4;source-code-pro.js"></script>
 
     <!-- Control the Flash of Unstyled Text (or FOUT) -->

--- a/docs/current/modules/filesystem/Directory.html
+++ b/docs/current/modules/filesystem/Directory.html
@@ -14,6 +14,7 @@
     <script type="text/javascript" src="../../assets/js/bootstrap.js"></script>
     <script type="text/javascript" src="../../assets/js/typeahead.js"></script>
     <script type="text/javascript" src="../../assets/js/main.js"></script>
+    <script type="text/javascript" src="../../assets/js/index.js"></script>
     <script src="http://use.edgefonts.net/source-sans-pro:n3,i3,n4,i4;source-code-pro.js"></script>
 
     <!-- Control the Flash of Unstyled Text (or FOUT) -->

--- a/docs/current/modules/filesystem/File.html
+++ b/docs/current/modules/filesystem/File.html
@@ -14,6 +14,7 @@
     <script type="text/javascript" src="../../assets/js/bootstrap.js"></script>
     <script type="text/javascript" src="../../assets/js/typeahead.js"></script>
     <script type="text/javascript" src="../../assets/js/main.js"></script>
+    <script type="text/javascript" src="../../assets/js/index.js"></script>
     <script src="http://use.edgefonts.net/source-sans-pro:n3,i3,n4,i4;source-code-pro.js"></script>
 
     <!-- Control the Flash of Unstyled Text (or FOUT) -->

--- a/docs/current/modules/filesystem/FileIndex.html
+++ b/docs/current/modules/filesystem/FileIndex.html
@@ -14,6 +14,7 @@
     <script type="text/javascript" src="../../assets/js/bootstrap.js"></script>
     <script type="text/javascript" src="../../assets/js/typeahead.js"></script>
     <script type="text/javascript" src="../../assets/js/main.js"></script>
+    <script type="text/javascript" src="../../assets/js/index.js"></script>
     <script src="http://use.edgefonts.net/source-sans-pro:n3,i3,n4,i4;source-code-pro.js"></script>
 
     <!-- Control the Flash of Unstyled Text (or FOUT) -->

--- a/docs/current/modules/filesystem/FileSystem.html
+++ b/docs/current/modules/filesystem/FileSystem.html
@@ -14,6 +14,7 @@
     <script type="text/javascript" src="../../assets/js/bootstrap.js"></script>
     <script type="text/javascript" src="../../assets/js/typeahead.js"></script>
     <script type="text/javascript" src="../../assets/js/main.js"></script>
+    <script type="text/javascript" src="../../assets/js/index.js"></script>
     <script src="http://use.edgefonts.net/source-sans-pro:n3,i3,n4,i4;source-code-pro.js"></script>
 
     <!-- Control the Flash of Unstyled Text (or FOUT) -->

--- a/docs/current/modules/filesystem/FileSystemEntry.html
+++ b/docs/current/modules/filesystem/FileSystemEntry.html
@@ -14,6 +14,7 @@
     <script type="text/javascript" src="../../assets/js/bootstrap.js"></script>
     <script type="text/javascript" src="../../assets/js/typeahead.js"></script>
     <script type="text/javascript" src="../../assets/js/main.js"></script>
+    <script type="text/javascript" src="../../assets/js/index.js"></script>
     <script src="http://use.edgefonts.net/source-sans-pro:n3,i3,n4,i4;source-code-pro.js"></script>
 
     <!-- Control the Flash of Unstyled Text (or FOUT) -->

--- a/docs/current/modules/filesystem/FileSystemError.html
+++ b/docs/current/modules/filesystem/FileSystemError.html
@@ -14,6 +14,7 @@
     <script type="text/javascript" src="../../assets/js/bootstrap.js"></script>
     <script type="text/javascript" src="../../assets/js/typeahead.js"></script>
     <script type="text/javascript" src="../../assets/js/main.js"></script>
+    <script type="text/javascript" src="../../assets/js/index.js"></script>
     <script src="http://use.edgefonts.net/source-sans-pro:n3,i3,n4,i4;source-code-pro.js"></script>
 
     <!-- Control the Flash of Unstyled Text (or FOUT) -->

--- a/docs/current/modules/filesystem/FileSystemStats.html
+++ b/docs/current/modules/filesystem/FileSystemStats.html
@@ -14,6 +14,7 @@
     <script type="text/javascript" src="../../assets/js/bootstrap.js"></script>
     <script type="text/javascript" src="../../assets/js/typeahead.js"></script>
     <script type="text/javascript" src="../../assets/js/main.js"></script>
+    <script type="text/javascript" src="../../assets/js/index.js"></script>
     <script src="http://use.edgefonts.net/source-sans-pro:n3,i3,n4,i4;source-code-pro.js"></script>
 
     <!-- Control the Flash of Unstyled Text (or FOUT) -->

--- a/docs/current/modules/filesystem/WatchedRoot.html
+++ b/docs/current/modules/filesystem/WatchedRoot.html
@@ -14,6 +14,7 @@
     <script type="text/javascript" src="../../assets/js/bootstrap.js"></script>
     <script type="text/javascript" src="../../assets/js/typeahead.js"></script>
     <script type="text/javascript" src="../../assets/js/main.js"></script>
+    <script type="text/javascript" src="../../assets/js/index.js"></script>
     <script src="http://use.edgefonts.net/source-sans-pro:n3,i3,n4,i4;source-code-pro.js"></script>
 
     <!-- Control the Flash of Unstyled Text (or FOUT) -->

--- a/docs/current/modules/filesystem/impls/appshell/AppshellFileSystem.html
+++ b/docs/current/modules/filesystem/impls/appshell/AppshellFileSystem.html
@@ -14,6 +14,7 @@
     <script type="text/javascript" src="../../../../assets/js/bootstrap.js"></script>
     <script type="text/javascript" src="../../../../assets/js/typeahead.js"></script>
     <script type="text/javascript" src="../../../../assets/js/main.js"></script>
+    <script type="text/javascript" src="../../../../assets/js/index.js"></script>
     <script src="http://use.edgefonts.net/source-sans-pro:n3,i3,n4,i4;source-code-pro.js"></script>
 
     <!-- Control the Flash of Unstyled Text (or FOUT) -->

--- a/docs/current/modules/filesystem/impls/appshell/node/FileWatcherDomain.html
+++ b/docs/current/modules/filesystem/impls/appshell/node/FileWatcherDomain.html
@@ -14,6 +14,7 @@
     <script type="text/javascript" src="../../../../../assets/js/bootstrap.js"></script>
     <script type="text/javascript" src="../../../../../assets/js/typeahead.js"></script>
     <script type="text/javascript" src="../../../../../assets/js/main.js"></script>
+    <script type="text/javascript" src="../../../../../assets/js/index.js"></script>
     <script src="http://use.edgefonts.net/source-sans-pro:n3,i3,n4,i4;source-code-pro.js"></script>
 
     <!-- Control the Flash of Unstyled Text (or FOUT) -->

--- a/docs/current/modules/help/HelpCommandHandlers.html
+++ b/docs/current/modules/help/HelpCommandHandlers.html
@@ -14,6 +14,7 @@
     <script type="text/javascript" src="../../assets/js/bootstrap.js"></script>
     <script type="text/javascript" src="../../assets/js/typeahead.js"></script>
     <script type="text/javascript" src="../../assets/js/main.js"></script>
+    <script type="text/javascript" src="../../assets/js/index.js"></script>
     <script src="http://use.edgefonts.net/source-sans-pro:n3,i3,n4,i4;source-code-pro.js"></script>
 
     <!-- Control the Flash of Unstyled Text (or FOUT) -->

--- a/docs/current/modules/language/CSSUtils.html
+++ b/docs/current/modules/language/CSSUtils.html
@@ -14,6 +14,7 @@
     <script type="text/javascript" src="../../assets/js/bootstrap.js"></script>
     <script type="text/javascript" src="../../assets/js/typeahead.js"></script>
     <script type="text/javascript" src="../../assets/js/main.js"></script>
+    <script type="text/javascript" src="../../assets/js/index.js"></script>
     <script src="http://use.edgefonts.net/source-sans-pro:n3,i3,n4,i4;source-code-pro.js"></script>
 
     <!-- Control the Flash of Unstyled Text (or FOUT) -->

--- a/docs/current/modules/language/CodeInspection.html
+++ b/docs/current/modules/language/CodeInspection.html
@@ -14,6 +14,7 @@
     <script type="text/javascript" src="../../assets/js/bootstrap.js"></script>
     <script type="text/javascript" src="../../assets/js/typeahead.js"></script>
     <script type="text/javascript" src="../../assets/js/main.js"></script>
+    <script type="text/javascript" src="../../assets/js/index.js"></script>
     <script src="http://use.edgefonts.net/source-sans-pro:n3,i3,n4,i4;source-code-pro.js"></script>
 
     <!-- Control the Flash of Unstyled Text (or FOUT) -->

--- a/docs/current/modules/language/HTMLDOMDiff.html
+++ b/docs/current/modules/language/HTMLDOMDiff.html
@@ -14,6 +14,7 @@
     <script type="text/javascript" src="../../assets/js/bootstrap.js"></script>
     <script type="text/javascript" src="../../assets/js/typeahead.js"></script>
     <script type="text/javascript" src="../../assets/js/main.js"></script>
+    <script type="text/javascript" src="../../assets/js/index.js"></script>
     <script src="http://use.edgefonts.net/source-sans-pro:n3,i3,n4,i4;source-code-pro.js"></script>
 
     <!-- Control the Flash of Unstyled Text (or FOUT) -->

--- a/docs/current/modules/language/HTMLInstrumentation.html
+++ b/docs/current/modules/language/HTMLInstrumentation.html
@@ -14,6 +14,7 @@
     <script type="text/javascript" src="../../assets/js/bootstrap.js"></script>
     <script type="text/javascript" src="../../assets/js/typeahead.js"></script>
     <script type="text/javascript" src="../../assets/js/main.js"></script>
+    <script type="text/javascript" src="../../assets/js/index.js"></script>
     <script src="http://use.edgefonts.net/source-sans-pro:n3,i3,n4,i4;source-code-pro.js"></script>
 
     <!-- Control the Flash of Unstyled Text (or FOUT) -->

--- a/docs/current/modules/language/HTMLSimpleDOM.html
+++ b/docs/current/modules/language/HTMLSimpleDOM.html
@@ -14,6 +14,7 @@
     <script type="text/javascript" src="../../assets/js/bootstrap.js"></script>
     <script type="text/javascript" src="../../assets/js/typeahead.js"></script>
     <script type="text/javascript" src="../../assets/js/main.js"></script>
+    <script type="text/javascript" src="../../assets/js/index.js"></script>
     <script src="http://use.edgefonts.net/source-sans-pro:n3,i3,n4,i4;source-code-pro.js"></script>
 
     <!-- Control the Flash of Unstyled Text (or FOUT) -->

--- a/docs/current/modules/language/HTMLTokenizer.html
+++ b/docs/current/modules/language/HTMLTokenizer.html
@@ -14,6 +14,7 @@
     <script type="text/javascript" src="../../assets/js/bootstrap.js"></script>
     <script type="text/javascript" src="../../assets/js/typeahead.js"></script>
     <script type="text/javascript" src="../../assets/js/main.js"></script>
+    <script type="text/javascript" src="../../assets/js/index.js"></script>
     <script src="http://use.edgefonts.net/source-sans-pro:n3,i3,n4,i4;source-code-pro.js"></script>
 
     <!-- Control the Flash of Unstyled Text (or FOUT) -->

--- a/docs/current/modules/language/HTMLUtils.html
+++ b/docs/current/modules/language/HTMLUtils.html
@@ -14,6 +14,7 @@
     <script type="text/javascript" src="../../assets/js/bootstrap.js"></script>
     <script type="text/javascript" src="../../assets/js/typeahead.js"></script>
     <script type="text/javascript" src="../../assets/js/main.js"></script>
+    <script type="text/javascript" src="../../assets/js/index.js"></script>
     <script src="http://use.edgefonts.net/source-sans-pro:n3,i3,n4,i4;source-code-pro.js"></script>
 
     <!-- Control the Flash of Unstyled Text (or FOUT) -->

--- a/docs/current/modules/language/JSONUtils.html
+++ b/docs/current/modules/language/JSONUtils.html
@@ -14,6 +14,7 @@
     <script type="text/javascript" src="../../assets/js/bootstrap.js"></script>
     <script type="text/javascript" src="../../assets/js/typeahead.js"></script>
     <script type="text/javascript" src="../../assets/js/main.js"></script>
+    <script type="text/javascript" src="../../assets/js/index.js"></script>
     <script src="http://use.edgefonts.net/source-sans-pro:n3,i3,n4,i4;source-code-pro.js"></script>
 
     <!-- Control the Flash of Unstyled Text (or FOUT) -->

--- a/docs/current/modules/language/JSUtils.html
+++ b/docs/current/modules/language/JSUtils.html
@@ -14,6 +14,7 @@
     <script type="text/javascript" src="../../assets/js/bootstrap.js"></script>
     <script type="text/javascript" src="../../assets/js/typeahead.js"></script>
     <script type="text/javascript" src="../../assets/js/main.js"></script>
+    <script type="text/javascript" src="../../assets/js/index.js"></script>
     <script src="http://use.edgefonts.net/source-sans-pro:n3,i3,n4,i4;source-code-pro.js"></script>
 
     <!-- Control the Flash of Unstyled Text (or FOUT) -->

--- a/docs/current/modules/language/LanguageManager.html
+++ b/docs/current/modules/language/LanguageManager.html
@@ -14,6 +14,7 @@
     <script type="text/javascript" src="../../assets/js/bootstrap.js"></script>
     <script type="text/javascript" src="../../assets/js/typeahead.js"></script>
     <script type="text/javascript" src="../../assets/js/main.js"></script>
+    <script type="text/javascript" src="../../assets/js/index.js"></script>
     <script src="http://use.edgefonts.net/source-sans-pro:n3,i3,n4,i4;source-code-pro.js"></script>
 
     <!-- Control the Flash of Unstyled Text (or FOUT) -->

--- a/docs/current/modules/language/XMLUtils.html
+++ b/docs/current/modules/language/XMLUtils.html
@@ -14,6 +14,7 @@
     <script type="text/javascript" src="../../assets/js/bootstrap.js"></script>
     <script type="text/javascript" src="../../assets/js/typeahead.js"></script>
     <script type="text/javascript" src="../../assets/js/main.js"></script>
+    <script type="text/javascript" src="../../assets/js/index.js"></script>
     <script src="http://use.edgefonts.net/source-sans-pro:n3,i3,n4,i4;source-code-pro.js"></script>
 
     <!-- Control the Flash of Unstyled Text (or FOUT) -->

--- a/docs/current/modules/main.html
+++ b/docs/current/modules/main.html
@@ -14,6 +14,7 @@
     <script type="text/javascript" src="../assets/js/bootstrap.js"></script>
     <script type="text/javascript" src="../assets/js/typeahead.js"></script>
     <script type="text/javascript" src="../assets/js/main.js"></script>
+    <script type="text/javascript" src="../assets/js/index.js"></script>
     <script src="http://use.edgefonts.net/source-sans-pro:n3,i3,n4,i4;source-code-pro.js"></script>
 
     <!-- Control the Flash of Unstyled Text (or FOUT) -->

--- a/docs/current/modules/preferences/PreferenceStorage.html
+++ b/docs/current/modules/preferences/PreferenceStorage.html
@@ -14,6 +14,7 @@
     <script type="text/javascript" src="../../assets/js/bootstrap.js"></script>
     <script type="text/javascript" src="../../assets/js/typeahead.js"></script>
     <script type="text/javascript" src="../../assets/js/main.js"></script>
+    <script type="text/javascript" src="../../assets/js/index.js"></script>
     <script src="http://use.edgefonts.net/source-sans-pro:n3,i3,n4,i4;source-code-pro.js"></script>
 
     <!-- Control the Flash of Unstyled Text (or FOUT) -->

--- a/docs/current/modules/preferences/PreferencesBase.html
+++ b/docs/current/modules/preferences/PreferencesBase.html
@@ -14,6 +14,7 @@
     <script type="text/javascript" src="../../assets/js/bootstrap.js"></script>
     <script type="text/javascript" src="../../assets/js/typeahead.js"></script>
     <script type="text/javascript" src="../../assets/js/main.js"></script>
+    <script type="text/javascript" src="../../assets/js/index.js"></script>
     <script src="http://use.edgefonts.net/source-sans-pro:n3,i3,n4,i4;source-code-pro.js"></script>
 
     <!-- Control the Flash of Unstyled Text (or FOUT) -->

--- a/docs/current/modules/preferences/PreferencesDialogs.html
+++ b/docs/current/modules/preferences/PreferencesDialogs.html
@@ -14,6 +14,7 @@
     <script type="text/javascript" src="../../assets/js/bootstrap.js"></script>
     <script type="text/javascript" src="../../assets/js/typeahead.js"></script>
     <script type="text/javascript" src="../../assets/js/main.js"></script>
+    <script type="text/javascript" src="../../assets/js/index.js"></script>
     <script src="http://use.edgefonts.net/source-sans-pro:n3,i3,n4,i4;source-code-pro.js"></script>
 
     <!-- Control the Flash of Unstyled Text (or FOUT) -->

--- a/docs/current/modules/preferences/PreferencesImpl.html
+++ b/docs/current/modules/preferences/PreferencesImpl.html
@@ -14,6 +14,7 @@
     <script type="text/javascript" src="../../assets/js/bootstrap.js"></script>
     <script type="text/javascript" src="../../assets/js/typeahead.js"></script>
     <script type="text/javascript" src="../../assets/js/main.js"></script>
+    <script type="text/javascript" src="../../assets/js/index.js"></script>
     <script src="http://use.edgefonts.net/source-sans-pro:n3,i3,n4,i4;source-code-pro.js"></script>
 
     <!-- Control the Flash of Unstyled Text (or FOUT) -->

--- a/docs/current/modules/preferences/PreferencesManager.html
+++ b/docs/current/modules/preferences/PreferencesManager.html
@@ -14,6 +14,7 @@
     <script type="text/javascript" src="../../assets/js/bootstrap.js"></script>
     <script type="text/javascript" src="../../assets/js/typeahead.js"></script>
     <script type="text/javascript" src="../../assets/js/main.js"></script>
+    <script type="text/javascript" src="../../assets/js/index.js"></script>
     <script src="http://use.edgefonts.net/source-sans-pro:n3,i3,n4,i4;source-code-pro.js"></script>
 
     <!-- Control the Flash of Unstyled Text (or FOUT) -->

--- a/docs/current/modules/project/FileIndexManager.html
+++ b/docs/current/modules/project/FileIndexManager.html
@@ -14,6 +14,7 @@
     <script type="text/javascript" src="../../assets/js/bootstrap.js"></script>
     <script type="text/javascript" src="../../assets/js/typeahead.js"></script>
     <script type="text/javascript" src="../../assets/js/main.js"></script>
+    <script type="text/javascript" src="../../assets/js/index.js"></script>
     <script src="http://use.edgefonts.net/source-sans-pro:n3,i3,n4,i4;source-code-pro.js"></script>
 
     <!-- Control the Flash of Unstyled Text (or FOUT) -->

--- a/docs/current/modules/project/FileSyncManager.html
+++ b/docs/current/modules/project/FileSyncManager.html
@@ -14,6 +14,7 @@
     <script type="text/javascript" src="../../assets/js/bootstrap.js"></script>
     <script type="text/javascript" src="../../assets/js/typeahead.js"></script>
     <script type="text/javascript" src="../../assets/js/main.js"></script>
+    <script type="text/javascript" src="../../assets/js/index.js"></script>
     <script src="http://use.edgefonts.net/source-sans-pro:n3,i3,n4,i4;source-code-pro.js"></script>
 
     <!-- Control the Flash of Unstyled Text (or FOUT) -->

--- a/docs/current/modules/project/FileTreeView.html
+++ b/docs/current/modules/project/FileTreeView.html
@@ -14,6 +14,7 @@
     <script type="text/javascript" src="../../assets/js/bootstrap.js"></script>
     <script type="text/javascript" src="../../assets/js/typeahead.js"></script>
     <script type="text/javascript" src="../../assets/js/main.js"></script>
+    <script type="text/javascript" src="../../assets/js/index.js"></script>
     <script src="http://use.edgefonts.net/source-sans-pro:n3,i3,n4,i4;source-code-pro.js"></script>
 
     <!-- Control the Flash of Unstyled Text (or FOUT) -->

--- a/docs/current/modules/project/FileTreeViewModel.html
+++ b/docs/current/modules/project/FileTreeViewModel.html
@@ -14,6 +14,7 @@
     <script type="text/javascript" src="../../assets/js/bootstrap.js"></script>
     <script type="text/javascript" src="../../assets/js/typeahead.js"></script>
     <script type="text/javascript" src="../../assets/js/main.js"></script>
+    <script type="text/javascript" src="../../assets/js/index.js"></script>
     <script src="http://use.edgefonts.net/source-sans-pro:n3,i3,n4,i4;source-code-pro.js"></script>
 
     <!-- Control the Flash of Unstyled Text (or FOUT) -->

--- a/docs/current/modules/project/FileViewController.html
+++ b/docs/current/modules/project/FileViewController.html
@@ -14,6 +14,7 @@
     <script type="text/javascript" src="../../assets/js/bootstrap.js"></script>
     <script type="text/javascript" src="../../assets/js/typeahead.js"></script>
     <script type="text/javascript" src="../../assets/js/main.js"></script>
+    <script type="text/javascript" src="../../assets/js/index.js"></script>
     <script src="http://use.edgefonts.net/source-sans-pro:n3,i3,n4,i4;source-code-pro.js"></script>
 
     <!-- Control the Flash of Unstyled Text (or FOUT) -->

--- a/docs/current/modules/project/ProjectManager.html
+++ b/docs/current/modules/project/ProjectManager.html
@@ -14,6 +14,7 @@
     <script type="text/javascript" src="../../assets/js/bootstrap.js"></script>
     <script type="text/javascript" src="../../assets/js/typeahead.js"></script>
     <script type="text/javascript" src="../../assets/js/main.js"></script>
+    <script type="text/javascript" src="../../assets/js/index.js"></script>
     <script src="http://use.edgefonts.net/source-sans-pro:n3,i3,n4,i4;source-code-pro.js"></script>
 
     <!-- Control the Flash of Unstyled Text (or FOUT) -->

--- a/docs/current/modules/project/ProjectModel.html
+++ b/docs/current/modules/project/ProjectModel.html
@@ -14,6 +14,7 @@
     <script type="text/javascript" src="../../assets/js/bootstrap.js"></script>
     <script type="text/javascript" src="../../assets/js/typeahead.js"></script>
     <script type="text/javascript" src="../../assets/js/main.js"></script>
+    <script type="text/javascript" src="../../assets/js/index.js"></script>
     <script src="http://use.edgefonts.net/source-sans-pro:n3,i3,n4,i4;source-code-pro.js"></script>
 
     <!-- Control the Flash of Unstyled Text (or FOUT) -->

--- a/docs/current/modules/project/SidebarView.html
+++ b/docs/current/modules/project/SidebarView.html
@@ -14,6 +14,7 @@
     <script type="text/javascript" src="../../assets/js/bootstrap.js"></script>
     <script type="text/javascript" src="../../assets/js/typeahead.js"></script>
     <script type="text/javascript" src="../../assets/js/main.js"></script>
+    <script type="text/javascript" src="../../assets/js/index.js"></script>
     <script src="http://use.edgefonts.net/source-sans-pro:n3,i3,n4,i4;source-code-pro.js"></script>
 
     <!-- Control the Flash of Unstyled Text (or FOUT) -->

--- a/docs/current/modules/project/WorkingSetSort.html
+++ b/docs/current/modules/project/WorkingSetSort.html
@@ -14,6 +14,7 @@
     <script type="text/javascript" src="../../assets/js/bootstrap.js"></script>
     <script type="text/javascript" src="../../assets/js/typeahead.js"></script>
     <script type="text/javascript" src="../../assets/js/main.js"></script>
+    <script type="text/javascript" src="../../assets/js/index.js"></script>
     <script src="http://use.edgefonts.net/source-sans-pro:n3,i3,n4,i4;source-code-pro.js"></script>
 
     <!-- Control the Flash of Unstyled Text (or FOUT) -->

--- a/docs/current/modules/project/WorkingSetView.html
+++ b/docs/current/modules/project/WorkingSetView.html
@@ -14,6 +14,7 @@
     <script type="text/javascript" src="../../assets/js/bootstrap.js"></script>
     <script type="text/javascript" src="../../assets/js/typeahead.js"></script>
     <script type="text/javascript" src="../../assets/js/main.js"></script>
+    <script type="text/javascript" src="../../assets/js/index.js"></script>
     <script src="http://use.edgefonts.net/source-sans-pro:n3,i3,n4,i4;source-code-pro.js"></script>
 
     <!-- Control the Flash of Unstyled Text (or FOUT) -->

--- a/docs/current/modules/search/FileFilters.html
+++ b/docs/current/modules/search/FileFilters.html
@@ -14,6 +14,7 @@
     <script type="text/javascript" src="../../assets/js/bootstrap.js"></script>
     <script type="text/javascript" src="../../assets/js/typeahead.js"></script>
     <script type="text/javascript" src="../../assets/js/main.js"></script>
+    <script type="text/javascript" src="../../assets/js/index.js"></script>
     <script src="http://use.edgefonts.net/source-sans-pro:n3,i3,n4,i4;source-code-pro.js"></script>
 
     <!-- Control the Flash of Unstyled Text (or FOUT) -->

--- a/docs/current/modules/search/FindBar.html
+++ b/docs/current/modules/search/FindBar.html
@@ -14,6 +14,7 @@
     <script type="text/javascript" src="../../assets/js/bootstrap.js"></script>
     <script type="text/javascript" src="../../assets/js/typeahead.js"></script>
     <script type="text/javascript" src="../../assets/js/main.js"></script>
+    <script type="text/javascript" src="../../assets/js/index.js"></script>
     <script src="http://use.edgefonts.net/source-sans-pro:n3,i3,n4,i4;source-code-pro.js"></script>
 
     <!-- Control the Flash of Unstyled Text (or FOUT) -->

--- a/docs/current/modules/search/FindInFiles.html
+++ b/docs/current/modules/search/FindInFiles.html
@@ -14,6 +14,7 @@
     <script type="text/javascript" src="../../assets/js/bootstrap.js"></script>
     <script type="text/javascript" src="../../assets/js/typeahead.js"></script>
     <script type="text/javascript" src="../../assets/js/main.js"></script>
+    <script type="text/javascript" src="../../assets/js/index.js"></script>
     <script src="http://use.edgefonts.net/source-sans-pro:n3,i3,n4,i4;source-code-pro.js"></script>
 
     <!-- Control the Flash of Unstyled Text (or FOUT) -->

--- a/docs/current/modules/search/FindInFilesUI.html
+++ b/docs/current/modules/search/FindInFilesUI.html
@@ -14,6 +14,7 @@
     <script type="text/javascript" src="../../assets/js/bootstrap.js"></script>
     <script type="text/javascript" src="../../assets/js/typeahead.js"></script>
     <script type="text/javascript" src="../../assets/js/main.js"></script>
+    <script type="text/javascript" src="../../assets/js/index.js"></script>
     <script src="http://use.edgefonts.net/source-sans-pro:n3,i3,n4,i4;source-code-pro.js"></script>
 
     <!-- Control the Flash of Unstyled Text (or FOUT) -->

--- a/docs/current/modules/search/FindReplace.html
+++ b/docs/current/modules/search/FindReplace.html
@@ -14,6 +14,7 @@
     <script type="text/javascript" src="../../assets/js/bootstrap.js"></script>
     <script type="text/javascript" src="../../assets/js/typeahead.js"></script>
     <script type="text/javascript" src="../../assets/js/main.js"></script>
+    <script type="text/javascript" src="../../assets/js/index.js"></script>
     <script src="http://use.edgefonts.net/source-sans-pro:n3,i3,n4,i4;source-code-pro.js"></script>
 
     <!-- Control the Flash of Unstyled Text (or FOUT) -->

--- a/docs/current/modules/search/FindUtils.html
+++ b/docs/current/modules/search/FindUtils.html
@@ -14,6 +14,7 @@
     <script type="text/javascript" src="../../assets/js/bootstrap.js"></script>
     <script type="text/javascript" src="../../assets/js/typeahead.js"></script>
     <script type="text/javascript" src="../../assets/js/main.js"></script>
+    <script type="text/javascript" src="../../assets/js/index.js"></script>
     <script src="http://use.edgefonts.net/source-sans-pro:n3,i3,n4,i4;source-code-pro.js"></script>
 
     <!-- Control the Flash of Unstyled Text (or FOUT) -->

--- a/docs/current/modules/search/QuickOpen.html
+++ b/docs/current/modules/search/QuickOpen.html
@@ -14,6 +14,7 @@
     <script type="text/javascript" src="../../assets/js/bootstrap.js"></script>
     <script type="text/javascript" src="../../assets/js/typeahead.js"></script>
     <script type="text/javascript" src="../../assets/js/main.js"></script>
+    <script type="text/javascript" src="../../assets/js/index.js"></script>
     <script src="http://use.edgefonts.net/source-sans-pro:n3,i3,n4,i4;source-code-pro.js"></script>
 
     <!-- Control the Flash of Unstyled Text (or FOUT) -->

--- a/docs/current/modules/search/QuickSearchField.html
+++ b/docs/current/modules/search/QuickSearchField.html
@@ -14,6 +14,7 @@
     <script type="text/javascript" src="../../assets/js/bootstrap.js"></script>
     <script type="text/javascript" src="../../assets/js/typeahead.js"></script>
     <script type="text/javascript" src="../../assets/js/main.js"></script>
+    <script type="text/javascript" src="../../assets/js/index.js"></script>
     <script src="http://use.edgefonts.net/source-sans-pro:n3,i3,n4,i4;source-code-pro.js"></script>
 
     <!-- Control the Flash of Unstyled Text (or FOUT) -->

--- a/docs/current/modules/search/ScrollTrackMarkers.html
+++ b/docs/current/modules/search/ScrollTrackMarkers.html
@@ -14,6 +14,7 @@
     <script type="text/javascript" src="../../assets/js/bootstrap.js"></script>
     <script type="text/javascript" src="../../assets/js/typeahead.js"></script>
     <script type="text/javascript" src="../../assets/js/main.js"></script>
+    <script type="text/javascript" src="../../assets/js/index.js"></script>
     <script src="http://use.edgefonts.net/source-sans-pro:n3,i3,n4,i4;source-code-pro.js"></script>
 
     <!-- Control the Flash of Unstyled Text (or FOUT) -->

--- a/docs/current/modules/search/SearchModel.html
+++ b/docs/current/modules/search/SearchModel.html
@@ -14,6 +14,7 @@
     <script type="text/javascript" src="../../assets/js/bootstrap.js"></script>
     <script type="text/javascript" src="../../assets/js/typeahead.js"></script>
     <script type="text/javascript" src="../../assets/js/main.js"></script>
+    <script type="text/javascript" src="../../assets/js/index.js"></script>
     <script src="http://use.edgefonts.net/source-sans-pro:n3,i3,n4,i4;source-code-pro.js"></script>
 
     <!-- Control the Flash of Unstyled Text (or FOUT) -->

--- a/docs/current/modules/search/SearchResultsView.html
+++ b/docs/current/modules/search/SearchResultsView.html
@@ -14,6 +14,7 @@
     <script type="text/javascript" src="../../assets/js/bootstrap.js"></script>
     <script type="text/javascript" src="../../assets/js/typeahead.js"></script>
     <script type="text/javascript" src="../../assets/js/main.js"></script>
+    <script type="text/javascript" src="../../assets/js/index.js"></script>
     <script src="http://use.edgefonts.net/source-sans-pro:n3,i3,n4,i4;source-code-pro.js"></script>
 
     <!-- Control the Flash of Unstyled Text (or FOUT) -->

--- a/docs/current/modules/search/node/FindInFilesDomain.html
+++ b/docs/current/modules/search/node/FindInFilesDomain.html
@@ -14,6 +14,7 @@
     <script type="text/javascript" src="../../../assets/js/bootstrap.js"></script>
     <script type="text/javascript" src="../../../assets/js/typeahead.js"></script>
     <script type="text/javascript" src="../../../assets/js/main.js"></script>
+    <script type="text/javascript" src="../../../assets/js/index.js"></script>
     <script src="http://use.edgefonts.net/source-sans-pro:n3,i3,n4,i4;source-code-pro.js"></script>
 
     <!-- Control the Flash of Unstyled Text (or FOUT) -->

--- a/docs/current/modules/strings.html
+++ b/docs/current/modules/strings.html
@@ -14,6 +14,7 @@
     <script type="text/javascript" src="../assets/js/bootstrap.js"></script>
     <script type="text/javascript" src="../assets/js/typeahead.js"></script>
     <script type="text/javascript" src="../assets/js/main.js"></script>
+    <script type="text/javascript" src="../assets/js/index.js"></script>
     <script src="http://use.edgefonts.net/source-sans-pro:n3,i3,n4,i4;source-code-pro.js"></script>
 
     <!-- Control the Flash of Unstyled Text (or FOUT) -->

--- a/docs/current/modules/utils/AnimationUtils.html
+++ b/docs/current/modules/utils/AnimationUtils.html
@@ -14,6 +14,7 @@
     <script type="text/javascript" src="../../assets/js/bootstrap.js"></script>
     <script type="text/javascript" src="../../assets/js/typeahead.js"></script>
     <script type="text/javascript" src="../../assets/js/main.js"></script>
+    <script type="text/javascript" src="../../assets/js/index.js"></script>
     <script src="http://use.edgefonts.net/source-sans-pro:n3,i3,n4,i4;source-code-pro.js"></script>
 
     <!-- Control the Flash of Unstyled Text (or FOUT) -->

--- a/docs/current/modules/utils/AppInit.html
+++ b/docs/current/modules/utils/AppInit.html
@@ -14,6 +14,7 @@
     <script type="text/javascript" src="../../assets/js/bootstrap.js"></script>
     <script type="text/javascript" src="../../assets/js/typeahead.js"></script>
     <script type="text/javascript" src="../../assets/js/main.js"></script>
+    <script type="text/javascript" src="../../assets/js/index.js"></script>
     <script src="http://use.edgefonts.net/source-sans-pro:n3,i3,n4,i4;source-code-pro.js"></script>
 
     <!-- Control the Flash of Unstyled Text (or FOUT) -->

--- a/docs/current/modules/utils/Async.html
+++ b/docs/current/modules/utils/Async.html
@@ -14,6 +14,7 @@
     <script type="text/javascript" src="../../assets/js/bootstrap.js"></script>
     <script type="text/javascript" src="../../assets/js/typeahead.js"></script>
     <script type="text/javascript" src="../../assets/js/main.js"></script>
+    <script type="text/javascript" src="../../assets/js/index.js"></script>
     <script src="http://use.edgefonts.net/source-sans-pro:n3,i3,n4,i4;source-code-pro.js"></script>
 
     <!-- Control the Flash of Unstyled Text (or FOUT) -->

--- a/docs/current/modules/utils/BuildInfoUtils.html
+++ b/docs/current/modules/utils/BuildInfoUtils.html
@@ -14,6 +14,7 @@
     <script type="text/javascript" src="../../assets/js/bootstrap.js"></script>
     <script type="text/javascript" src="../../assets/js/typeahead.js"></script>
     <script type="text/javascript" src="../../assets/js/main.js"></script>
+    <script type="text/javascript" src="../../assets/js/index.js"></script>
     <script src="http://use.edgefonts.net/source-sans-pro:n3,i3,n4,i4;source-code-pro.js"></script>
 
     <!-- Control the Flash of Unstyled Text (or FOUT) -->

--- a/docs/current/modules/utils/ColorUtils.html
+++ b/docs/current/modules/utils/ColorUtils.html
@@ -14,6 +14,7 @@
     <script type="text/javascript" src="../../assets/js/bootstrap.js"></script>
     <script type="text/javascript" src="../../assets/js/typeahead.js"></script>
     <script type="text/javascript" src="../../assets/js/main.js"></script>
+    <script type="text/javascript" src="../../assets/js/index.js"></script>
     <script src="http://use.edgefonts.net/source-sans-pro:n3,i3,n4,i4;source-code-pro.js"></script>
 
     <!-- Control the Flash of Unstyled Text (or FOUT) -->

--- a/docs/current/modules/utils/Compatibility.html
+++ b/docs/current/modules/utils/Compatibility.html
@@ -14,6 +14,7 @@
     <script type="text/javascript" src="../../assets/js/bootstrap.js"></script>
     <script type="text/javascript" src="../../assets/js/typeahead.js"></script>
     <script type="text/javascript" src="../../assets/js/main.js"></script>
+    <script type="text/javascript" src="../../assets/js/index.js"></script>
     <script src="http://use.edgefonts.net/source-sans-pro:n3,i3,n4,i4;source-code-pro.js"></script>
 
     <!-- Control the Flash of Unstyled Text (or FOUT) -->

--- a/docs/current/modules/utils/DeprecationWarning.html
+++ b/docs/current/modules/utils/DeprecationWarning.html
@@ -14,6 +14,7 @@
     <script type="text/javascript" src="../../assets/js/bootstrap.js"></script>
     <script type="text/javascript" src="../../assets/js/typeahead.js"></script>
     <script type="text/javascript" src="../../assets/js/main.js"></script>
+    <script type="text/javascript" src="../../assets/js/index.js"></script>
     <script src="http://use.edgefonts.net/source-sans-pro:n3,i3,n4,i4;source-code-pro.js"></script>
 
     <!-- Control the Flash of Unstyled Text (or FOUT) -->

--- a/docs/current/modules/utils/DragAndDrop.html
+++ b/docs/current/modules/utils/DragAndDrop.html
@@ -14,6 +14,7 @@
     <script type="text/javascript" src="../../assets/js/bootstrap.js"></script>
     <script type="text/javascript" src="../../assets/js/typeahead.js"></script>
     <script type="text/javascript" src="../../assets/js/main.js"></script>
+    <script type="text/javascript" src="../../assets/js/index.js"></script>
     <script src="http://use.edgefonts.net/source-sans-pro:n3,i3,n4,i4;source-code-pro.js"></script>
 
     <!-- Control the Flash of Unstyled Text (or FOUT) -->

--- a/docs/current/modules/utils/DropdownEventHandler.html
+++ b/docs/current/modules/utils/DropdownEventHandler.html
@@ -14,6 +14,7 @@
     <script type="text/javascript" src="../../assets/js/bootstrap.js"></script>
     <script type="text/javascript" src="../../assets/js/typeahead.js"></script>
     <script type="text/javascript" src="../../assets/js/main.js"></script>
+    <script type="text/javascript" src="../../assets/js/index.js"></script>
     <script src="http://use.edgefonts.net/source-sans-pro:n3,i3,n4,i4;source-code-pro.js"></script>
 
     <!-- Control the Flash of Unstyled Text (or FOUT) -->

--- a/docs/current/modules/utils/EventDispatcher.html
+++ b/docs/current/modules/utils/EventDispatcher.html
@@ -14,6 +14,7 @@
     <script type="text/javascript" src="../../assets/js/bootstrap.js"></script>
     <script type="text/javascript" src="../../assets/js/typeahead.js"></script>
     <script type="text/javascript" src="../../assets/js/main.js"></script>
+    <script type="text/javascript" src="../../assets/js/index.js"></script>
     <script src="http://use.edgefonts.net/source-sans-pro:n3,i3,n4,i4;source-code-pro.js"></script>
 
     <!-- Control the Flash of Unstyled Text (or FOUT) -->

--- a/docs/current/modules/utils/ExtensionLoader.html
+++ b/docs/current/modules/utils/ExtensionLoader.html
@@ -14,6 +14,7 @@
     <script type="text/javascript" src="../../assets/js/bootstrap.js"></script>
     <script type="text/javascript" src="../../assets/js/typeahead.js"></script>
     <script type="text/javascript" src="../../assets/js/main.js"></script>
+    <script type="text/javascript" src="../../assets/js/index.js"></script>
     <script src="http://use.edgefonts.net/source-sans-pro:n3,i3,n4,i4;source-code-pro.js"></script>
 
     <!-- Control the Flash of Unstyled Text (or FOUT) -->

--- a/docs/current/modules/utils/ExtensionUtils.html
+++ b/docs/current/modules/utils/ExtensionUtils.html
@@ -14,6 +14,7 @@
     <script type="text/javascript" src="../../assets/js/bootstrap.js"></script>
     <script type="text/javascript" src="../../assets/js/typeahead.js"></script>
     <script type="text/javascript" src="../../assets/js/main.js"></script>
+    <script type="text/javascript" src="../../assets/js/index.js"></script>
     <script src="http://use.edgefonts.net/source-sans-pro:n3,i3,n4,i4;source-code-pro.js"></script>
 
     <!-- Control the Flash of Unstyled Text (or FOUT) -->

--- a/docs/current/modules/utils/Global.html
+++ b/docs/current/modules/utils/Global.html
@@ -14,6 +14,7 @@
     <script type="text/javascript" src="../../assets/js/bootstrap.js"></script>
     <script type="text/javascript" src="../../assets/js/typeahead.js"></script>
     <script type="text/javascript" src="../../assets/js/main.js"></script>
+    <script type="text/javascript" src="../../assets/js/index.js"></script>
     <script src="http://use.edgefonts.net/source-sans-pro:n3,i3,n4,i4;source-code-pro.js"></script>
 
     <!-- Control the Flash of Unstyled Text (or FOUT) -->

--- a/docs/current/modules/utils/HealthLogger.html
+++ b/docs/current/modules/utils/HealthLogger.html
@@ -14,6 +14,7 @@
     <script type="text/javascript" src="../../assets/js/bootstrap.js"></script>
     <script type="text/javascript" src="../../assets/js/typeahead.js"></script>
     <script type="text/javascript" src="../../assets/js/main.js"></script>
+    <script type="text/javascript" src="../../assets/js/index.js"></script>
     <script src="http://use.edgefonts.net/source-sans-pro:n3,i3,n4,i4;source-code-pro.js"></script>
 
     <!-- Control the Flash of Unstyled Text (or FOUT) -->

--- a/docs/current/modules/utils/KeyEvent.html
+++ b/docs/current/modules/utils/KeyEvent.html
@@ -14,6 +14,7 @@
     <script type="text/javascript" src="../../assets/js/bootstrap.js"></script>
     <script type="text/javascript" src="../../assets/js/typeahead.js"></script>
     <script type="text/javascript" src="../../assets/js/main.js"></script>
+    <script type="text/javascript" src="../../assets/js/index.js"></script>
     <script src="http://use.edgefonts.net/source-sans-pro:n3,i3,n4,i4;source-code-pro.js"></script>
 
     <!-- Control the Flash of Unstyled Text (or FOUT) -->

--- a/docs/current/modules/utils/LocalizationUtils.html
+++ b/docs/current/modules/utils/LocalizationUtils.html
@@ -14,6 +14,7 @@
     <script type="text/javascript" src="../../assets/js/bootstrap.js"></script>
     <script type="text/javascript" src="../../assets/js/typeahead.js"></script>
     <script type="text/javascript" src="../../assets/js/main.js"></script>
+    <script type="text/javascript" src="../../assets/js/index.js"></script>
     <script src="http://use.edgefonts.net/source-sans-pro:n3,i3,n4,i4;source-code-pro.js"></script>
 
     <!-- Control the Flash of Unstyled Text (or FOUT) -->

--- a/docs/current/modules/utils/NativeApp.html
+++ b/docs/current/modules/utils/NativeApp.html
@@ -14,6 +14,7 @@
     <script type="text/javascript" src="../../assets/js/bootstrap.js"></script>
     <script type="text/javascript" src="../../assets/js/typeahead.js"></script>
     <script type="text/javascript" src="../../assets/js/main.js"></script>
+    <script type="text/javascript" src="../../assets/js/index.js"></script>
     <script src="http://use.edgefonts.net/source-sans-pro:n3,i3,n4,i4;source-code-pro.js"></script>
 
     <!-- Control the Flash of Unstyled Text (or FOUT) -->

--- a/docs/current/modules/utils/NodeConnection.html
+++ b/docs/current/modules/utils/NodeConnection.html
@@ -14,6 +14,7 @@
     <script type="text/javascript" src="../../assets/js/bootstrap.js"></script>
     <script type="text/javascript" src="../../assets/js/typeahead.js"></script>
     <script type="text/javascript" src="../../assets/js/main.js"></script>
+    <script type="text/javascript" src="../../assets/js/index.js"></script>
     <script src="http://use.edgefonts.net/source-sans-pro:n3,i3,n4,i4;source-code-pro.js"></script>
 
     <!-- Control the Flash of Unstyled Text (or FOUT) -->

--- a/docs/current/modules/utils/NodeDomain.html
+++ b/docs/current/modules/utils/NodeDomain.html
@@ -14,6 +14,7 @@
     <script type="text/javascript" src="../../assets/js/bootstrap.js"></script>
     <script type="text/javascript" src="../../assets/js/typeahead.js"></script>
     <script type="text/javascript" src="../../assets/js/main.js"></script>
+    <script type="text/javascript" src="../../assets/js/index.js"></script>
     <script src="http://use.edgefonts.net/source-sans-pro:n3,i3,n4,i4;source-code-pro.js"></script>
 
     <!-- Control the Flash of Unstyled Text (or FOUT) -->

--- a/docs/current/modules/utils/PerfUtils.html
+++ b/docs/current/modules/utils/PerfUtils.html
@@ -14,6 +14,7 @@
     <script type="text/javascript" src="../../assets/js/bootstrap.js"></script>
     <script type="text/javascript" src="../../assets/js/typeahead.js"></script>
     <script type="text/javascript" src="../../assets/js/main.js"></script>
+    <script type="text/javascript" src="../../assets/js/index.js"></script>
     <script src="http://use.edgefonts.net/source-sans-pro:n3,i3,n4,i4;source-code-pro.js"></script>
 
     <!-- Control the Flash of Unstyled Text (or FOUT) -->

--- a/docs/current/modules/utils/Resizer.html
+++ b/docs/current/modules/utils/Resizer.html
@@ -14,6 +14,7 @@
     <script type="text/javascript" src="../../assets/js/bootstrap.js"></script>
     <script type="text/javascript" src="../../assets/js/typeahead.js"></script>
     <script type="text/javascript" src="../../assets/js/main.js"></script>
+    <script type="text/javascript" src="../../assets/js/index.js"></script>
     <script src="http://use.edgefonts.net/source-sans-pro:n3,i3,n4,i4;source-code-pro.js"></script>
 
     <!-- Control the Flash of Unstyled Text (or FOUT) -->

--- a/docs/current/modules/utils/ShellAPI.html
+++ b/docs/current/modules/utils/ShellAPI.html
@@ -14,6 +14,7 @@
     <script type="text/javascript" src="../../assets/js/bootstrap.js"></script>
     <script type="text/javascript" src="../../assets/js/typeahead.js"></script>
     <script type="text/javascript" src="../../assets/js/main.js"></script>
+    <script type="text/javascript" src="../../assets/js/index.js"></script>
     <script src="http://use.edgefonts.net/source-sans-pro:n3,i3,n4,i4;source-code-pro.js"></script>
 
     <!-- Control the Flash of Unstyled Text (or FOUT) -->

--- a/docs/current/modules/utils/StringMatch.html
+++ b/docs/current/modules/utils/StringMatch.html
@@ -14,6 +14,7 @@
     <script type="text/javascript" src="../../assets/js/bootstrap.js"></script>
     <script type="text/javascript" src="../../assets/js/typeahead.js"></script>
     <script type="text/javascript" src="../../assets/js/main.js"></script>
+    <script type="text/javascript" src="../../assets/js/index.js"></script>
     <script src="http://use.edgefonts.net/source-sans-pro:n3,i3,n4,i4;source-code-pro.js"></script>
 
     <!-- Control the Flash of Unstyled Text (or FOUT) -->

--- a/docs/current/modules/utils/StringUtils.html
+++ b/docs/current/modules/utils/StringUtils.html
@@ -14,6 +14,7 @@
     <script type="text/javascript" src="../../assets/js/bootstrap.js"></script>
     <script type="text/javascript" src="../../assets/js/typeahead.js"></script>
     <script type="text/javascript" src="../../assets/js/main.js"></script>
+    <script type="text/javascript" src="../../assets/js/index.js"></script>
     <script src="http://use.edgefonts.net/source-sans-pro:n3,i3,n4,i4;source-code-pro.js"></script>
 
     <!-- Control the Flash of Unstyled Text (or FOUT) -->

--- a/docs/current/modules/utils/TokenUtils.html
+++ b/docs/current/modules/utils/TokenUtils.html
@@ -14,6 +14,7 @@
     <script type="text/javascript" src="../../assets/js/bootstrap.js"></script>
     <script type="text/javascript" src="../../assets/js/typeahead.js"></script>
     <script type="text/javascript" src="../../assets/js/main.js"></script>
+    <script type="text/javascript" src="../../assets/js/index.js"></script>
     <script src="http://use.edgefonts.net/source-sans-pro:n3,i3,n4,i4;source-code-pro.js"></script>
 
     <!-- Control the Flash of Unstyled Text (or FOUT) -->

--- a/docs/current/modules/utils/UpdateNotification.html
+++ b/docs/current/modules/utils/UpdateNotification.html
@@ -14,6 +14,7 @@
     <script type="text/javascript" src="../../assets/js/bootstrap.js"></script>
     <script type="text/javascript" src="../../assets/js/typeahead.js"></script>
     <script type="text/javascript" src="../../assets/js/main.js"></script>
+    <script type="text/javascript" src="../../assets/js/index.js"></script>
     <script src="http://use.edgefonts.net/source-sans-pro:n3,i3,n4,i4;source-code-pro.js"></script>
 
     <!-- Control the Flash of Unstyled Text (or FOUT) -->

--- a/docs/current/modules/utils/UrlParams.html
+++ b/docs/current/modules/utils/UrlParams.html
@@ -14,6 +14,7 @@
     <script type="text/javascript" src="../../assets/js/bootstrap.js"></script>
     <script type="text/javascript" src="../../assets/js/typeahead.js"></script>
     <script type="text/javascript" src="../../assets/js/main.js"></script>
+    <script type="text/javascript" src="../../assets/js/index.js"></script>
     <script src="http://use.edgefonts.net/source-sans-pro:n3,i3,n4,i4;source-code-pro.js"></script>
 
     <!-- Control the Flash of Unstyled Text (or FOUT) -->

--- a/docs/current/modules/utils/ValidationUtils.html
+++ b/docs/current/modules/utils/ValidationUtils.html
@@ -14,6 +14,7 @@
     <script type="text/javascript" src="../../assets/js/bootstrap.js"></script>
     <script type="text/javascript" src="../../assets/js/typeahead.js"></script>
     <script type="text/javascript" src="../../assets/js/main.js"></script>
+    <script type="text/javascript" src="../../assets/js/index.js"></script>
     <script src="http://use.edgefonts.net/source-sans-pro:n3,i3,n4,i4;source-code-pro.js"></script>
 
     <!-- Control the Flash of Unstyled Text (or FOUT) -->

--- a/docs/current/modules/utils/ViewUtils.html
+++ b/docs/current/modules/utils/ViewUtils.html
@@ -14,6 +14,7 @@
     <script type="text/javascript" src="../../assets/js/bootstrap.js"></script>
     <script type="text/javascript" src="../../assets/js/typeahead.js"></script>
     <script type="text/javascript" src="../../assets/js/main.js"></script>
+    <script type="text/javascript" src="../../assets/js/index.js"></script>
     <script src="http://use.edgefonts.net/source-sans-pro:n3,i3,n4,i4;source-code-pro.js"></script>
 
     <!-- Control the Flash of Unstyled Text (or FOUT) -->

--- a/docs/current/modules/view/MainViewFactory.html
+++ b/docs/current/modules/view/MainViewFactory.html
@@ -14,6 +14,7 @@
     <script type="text/javascript" src="../../assets/js/bootstrap.js"></script>
     <script type="text/javascript" src="../../assets/js/typeahead.js"></script>
     <script type="text/javascript" src="../../assets/js/main.js"></script>
+    <script type="text/javascript" src="../../assets/js/index.js"></script>
     <script src="http://use.edgefonts.net/source-sans-pro:n3,i3,n4,i4;source-code-pro.js"></script>
 
     <!-- Control the Flash of Unstyled Text (or FOUT) -->

--- a/docs/current/modules/view/MainViewManager.html
+++ b/docs/current/modules/view/MainViewManager.html
@@ -14,6 +14,7 @@
     <script type="text/javascript" src="../../assets/js/bootstrap.js"></script>
     <script type="text/javascript" src="../../assets/js/typeahead.js"></script>
     <script type="text/javascript" src="../../assets/js/main.js"></script>
+    <script type="text/javascript" src="../../assets/js/index.js"></script>
     <script src="http://use.edgefonts.net/source-sans-pro:n3,i3,n4,i4;source-code-pro.js"></script>
 
     <!-- Control the Flash of Unstyled Text (or FOUT) -->

--- a/docs/current/modules/view/Pane.html
+++ b/docs/current/modules/view/Pane.html
@@ -14,6 +14,7 @@
     <script type="text/javascript" src="../../assets/js/bootstrap.js"></script>
     <script type="text/javascript" src="../../assets/js/typeahead.js"></script>
     <script type="text/javascript" src="../../assets/js/main.js"></script>
+    <script type="text/javascript" src="../../assets/js/index.js"></script>
     <script src="http://use.edgefonts.net/source-sans-pro:n3,i3,n4,i4;source-code-pro.js"></script>
 
     <!-- Control the Flash of Unstyled Text (or FOUT) -->

--- a/docs/current/modules/view/PanelManager.html
+++ b/docs/current/modules/view/PanelManager.html
@@ -14,6 +14,7 @@
     <script type="text/javascript" src="../../assets/js/bootstrap.js"></script>
     <script type="text/javascript" src="../../assets/js/typeahead.js"></script>
     <script type="text/javascript" src="../../assets/js/main.js"></script>
+    <script type="text/javascript" src="../../assets/js/index.js"></script>
     <script src="http://use.edgefonts.net/source-sans-pro:n3,i3,n4,i4;source-code-pro.js"></script>
 
     <!-- Control the Flash of Unstyled Text (or FOUT) -->

--- a/docs/current/modules/view/ThemeManager.html
+++ b/docs/current/modules/view/ThemeManager.html
@@ -14,6 +14,7 @@
     <script type="text/javascript" src="../../assets/js/bootstrap.js"></script>
     <script type="text/javascript" src="../../assets/js/typeahead.js"></script>
     <script type="text/javascript" src="../../assets/js/main.js"></script>
+    <script type="text/javascript" src="../../assets/js/index.js"></script>
     <script src="http://use.edgefonts.net/source-sans-pro:n3,i3,n4,i4;source-code-pro.js"></script>
 
     <!-- Control the Flash of Unstyled Text (or FOUT) -->

--- a/docs/current/modules/view/ThemeSettings.html
+++ b/docs/current/modules/view/ThemeSettings.html
@@ -14,6 +14,7 @@
     <script type="text/javascript" src="../../assets/js/bootstrap.js"></script>
     <script type="text/javascript" src="../../assets/js/typeahead.js"></script>
     <script type="text/javascript" src="../../assets/js/main.js"></script>
+    <script type="text/javascript" src="../../assets/js/index.js"></script>
     <script src="http://use.edgefonts.net/source-sans-pro:n3,i3,n4,i4;source-code-pro.js"></script>
 
     <!-- Control the Flash of Unstyled Text (or FOUT) -->

--- a/docs/current/modules/view/ThemeView.html
+++ b/docs/current/modules/view/ThemeView.html
@@ -14,6 +14,7 @@
     <script type="text/javascript" src="../../assets/js/bootstrap.js"></script>
     <script type="text/javascript" src="../../assets/js/typeahead.js"></script>
     <script type="text/javascript" src="../../assets/js/main.js"></script>
+    <script type="text/javascript" src="../../assets/js/index.js"></script>
     <script src="http://use.edgefonts.net/source-sans-pro:n3,i3,n4,i4;source-code-pro.js"></script>
 
     <!-- Control the Flash of Unstyled Text (or FOUT) -->

--- a/docs/current/modules/view/ViewCommandHandlers.html
+++ b/docs/current/modules/view/ViewCommandHandlers.html
@@ -14,6 +14,7 @@
     <script type="text/javascript" src="../../assets/js/bootstrap.js"></script>
     <script type="text/javascript" src="../../assets/js/typeahead.js"></script>
     <script type="text/javascript" src="../../assets/js/main.js"></script>
+    <script type="text/javascript" src="../../assets/js/index.js"></script>
     <script src="http://use.edgefonts.net/source-sans-pro:n3,i3,n4,i4;source-code-pro.js"></script>
 
     <!-- Control the Flash of Unstyled Text (or FOUT) -->

--- a/docs/current/modules/view/ViewStateManager.html
+++ b/docs/current/modules/view/ViewStateManager.html
@@ -14,6 +14,7 @@
     <script type="text/javascript" src="../../assets/js/bootstrap.js"></script>
     <script type="text/javascript" src="../../assets/js/typeahead.js"></script>
     <script type="text/javascript" src="../../assets/js/main.js"></script>
+    <script type="text/javascript" src="../../assets/js/index.js"></script>
     <script src="http://use.edgefonts.net/source-sans-pro:n3,i3,n4,i4;source-code-pro.js"></script>
 
     <!-- Control the Flash of Unstyled Text (or FOUT) -->

--- a/docs/current/modules/view/WorkspaceManager.html
+++ b/docs/current/modules/view/WorkspaceManager.html
@@ -14,6 +14,7 @@
     <script type="text/javascript" src="../../assets/js/bootstrap.js"></script>
     <script type="text/javascript" src="../../assets/js/typeahead.js"></script>
     <script type="text/javascript" src="../../assets/js/main.js"></script>
+    <script type="text/javascript" src="../../assets/js/index.js"></script>
     <script src="http://use.edgefonts.net/source-sans-pro:n3,i3,n4,i4;source-code-pro.js"></script>
 
     <!-- Control the Flash of Unstyled Text (or FOUT) -->

--- a/docs/current/modules/widgets/DefaultDialogs.html
+++ b/docs/current/modules/widgets/DefaultDialogs.html
@@ -14,6 +14,7 @@
     <script type="text/javascript" src="../../assets/js/bootstrap.js"></script>
     <script type="text/javascript" src="../../assets/js/typeahead.js"></script>
     <script type="text/javascript" src="../../assets/js/main.js"></script>
+    <script type="text/javascript" src="../../assets/js/index.js"></script>
     <script src="http://use.edgefonts.net/source-sans-pro:n3,i3,n4,i4;source-code-pro.js"></script>
 
     <!-- Control the Flash of Unstyled Text (or FOUT) -->

--- a/docs/current/modules/widgets/Dialogs.html
+++ b/docs/current/modules/widgets/Dialogs.html
@@ -14,6 +14,7 @@
     <script type="text/javascript" src="../../assets/js/bootstrap.js"></script>
     <script type="text/javascript" src="../../assets/js/typeahead.js"></script>
     <script type="text/javascript" src="../../assets/js/main.js"></script>
+    <script type="text/javascript" src="../../assets/js/index.js"></script>
     <script src="http://use.edgefonts.net/source-sans-pro:n3,i3,n4,i4;source-code-pro.js"></script>
 
     <!-- Control the Flash of Unstyled Text (or FOUT) -->

--- a/docs/current/modules/widgets/DropdownButton.html
+++ b/docs/current/modules/widgets/DropdownButton.html
@@ -14,6 +14,7 @@
     <script type="text/javascript" src="../../assets/js/bootstrap.js"></script>
     <script type="text/javascript" src="../../assets/js/typeahead.js"></script>
     <script type="text/javascript" src="../../assets/js/main.js"></script>
+    <script type="text/javascript" src="../../assets/js/index.js"></script>
     <script src="http://use.edgefonts.net/source-sans-pro:n3,i3,n4,i4;source-code-pro.js"></script>
 
     <!-- Control the Flash of Unstyled Text (or FOUT) -->

--- a/docs/current/modules/widgets/ModalBar.html
+++ b/docs/current/modules/widgets/ModalBar.html
@@ -14,6 +14,7 @@
     <script type="text/javascript" src="../../assets/js/bootstrap.js"></script>
     <script type="text/javascript" src="../../assets/js/typeahead.js"></script>
     <script type="text/javascript" src="../../assets/js/main.js"></script>
+    <script type="text/javascript" src="../../assets/js/index.js"></script>
     <script src="http://use.edgefonts.net/source-sans-pro:n3,i3,n4,i4;source-code-pro.js"></script>
 
     <!-- Control the Flash of Unstyled Text (or FOUT) -->

--- a/docs/current/modules/widgets/PopUpManager.html
+++ b/docs/current/modules/widgets/PopUpManager.html
@@ -14,6 +14,7 @@
     <script type="text/javascript" src="../../assets/js/bootstrap.js"></script>
     <script type="text/javascript" src="../../assets/js/typeahead.js"></script>
     <script type="text/javascript" src="../../assets/js/main.js"></script>
+    <script type="text/javascript" src="../../assets/js/index.js"></script>
     <script src="http://use.edgefonts.net/source-sans-pro:n3,i3,n4,i4;source-code-pro.js"></script>
 
     <!-- Control the Flash of Unstyled Text (or FOUT) -->

--- a/docs/current/modules/widgets/StatusBar.html
+++ b/docs/current/modules/widgets/StatusBar.html
@@ -14,6 +14,7 @@
     <script type="text/javascript" src="../../assets/js/bootstrap.js"></script>
     <script type="text/javascript" src="../../assets/js/typeahead.js"></script>
     <script type="text/javascript" src="../../assets/js/main.js"></script>
+    <script type="text/javascript" src="../../assets/js/index.js"></script>
     <script src="http://use.edgefonts.net/source-sans-pro:n3,i3,n4,i4;source-code-pro.js"></script>
 
     <!-- Control the Flash of Unstyled Text (or FOUT) -->

--- a/docs/current/modules/widgets/bootstrap-alerts.html
+++ b/docs/current/modules/widgets/bootstrap-alerts.html
@@ -14,6 +14,7 @@
     <script type="text/javascript" src="../../assets/js/bootstrap.js"></script>
     <script type="text/javascript" src="../../assets/js/typeahead.js"></script>
     <script type="text/javascript" src="../../assets/js/main.js"></script>
+    <script type="text/javascript" src="../../assets/js/index.js"></script>
     <script src="http://use.edgefonts.net/source-sans-pro:n3,i3,n4,i4;source-code-pro.js"></script>
 
     <!-- Control the Flash of Unstyled Text (or FOUT) -->

--- a/docs/current/modules/widgets/bootstrap-button.html
+++ b/docs/current/modules/widgets/bootstrap-button.html
@@ -14,6 +14,7 @@
     <script type="text/javascript" src="../../assets/js/bootstrap.js"></script>
     <script type="text/javascript" src="../../assets/js/typeahead.js"></script>
     <script type="text/javascript" src="../../assets/js/main.js"></script>
+    <script type="text/javascript" src="../../assets/js/index.js"></script>
     <script src="http://use.edgefonts.net/source-sans-pro:n3,i3,n4,i4;source-code-pro.js"></script>
 
     <!-- Control the Flash of Unstyled Text (or FOUT) -->

--- a/docs/current/modules/widgets/bootstrap-dropdown.html
+++ b/docs/current/modules/widgets/bootstrap-dropdown.html
@@ -14,6 +14,7 @@
     <script type="text/javascript" src="../../assets/js/bootstrap.js"></script>
     <script type="text/javascript" src="../../assets/js/typeahead.js"></script>
     <script type="text/javascript" src="../../assets/js/main.js"></script>
+    <script type="text/javascript" src="../../assets/js/index.js"></script>
     <script src="http://use.edgefonts.net/source-sans-pro:n3,i3,n4,i4;source-code-pro.js"></script>
 
     <!-- Control the Flash of Unstyled Text (or FOUT) -->

--- a/docs/current/modules/widgets/bootstrap-modal.html
+++ b/docs/current/modules/widgets/bootstrap-modal.html
@@ -14,6 +14,7 @@
     <script type="text/javascript" src="../../assets/js/bootstrap.js"></script>
     <script type="text/javascript" src="../../assets/js/typeahead.js"></script>
     <script type="text/javascript" src="../../assets/js/main.js"></script>
+    <script type="text/javascript" src="../../assets/js/index.js"></script>
     <script src="http://use.edgefonts.net/source-sans-pro:n3,i3,n4,i4;source-code-pro.js"></script>
 
     <!-- Control the Flash of Unstyled Text (or FOUT) -->

--- a/docs/current/modules/widgets/bootstrap-popover.html
+++ b/docs/current/modules/widgets/bootstrap-popover.html
@@ -14,6 +14,7 @@
     <script type="text/javascript" src="../../assets/js/bootstrap.js"></script>
     <script type="text/javascript" src="../../assets/js/typeahead.js"></script>
     <script type="text/javascript" src="../../assets/js/main.js"></script>
+    <script type="text/javascript" src="../../assets/js/index.js"></script>
     <script src="http://use.edgefonts.net/source-sans-pro:n3,i3,n4,i4;source-code-pro.js"></script>
 
     <!-- Control the Flash of Unstyled Text (or FOUT) -->

--- a/docs/current/modules/widgets/bootstrap-scrollspy.html
+++ b/docs/current/modules/widgets/bootstrap-scrollspy.html
@@ -14,6 +14,7 @@
     <script type="text/javascript" src="../../assets/js/bootstrap.js"></script>
     <script type="text/javascript" src="../../assets/js/typeahead.js"></script>
     <script type="text/javascript" src="../../assets/js/main.js"></script>
+    <script type="text/javascript" src="../../assets/js/index.js"></script>
     <script src="http://use.edgefonts.net/source-sans-pro:n3,i3,n4,i4;source-code-pro.js"></script>
 
     <!-- Control the Flash of Unstyled Text (or FOUT) -->

--- a/docs/current/modules/widgets/bootstrap-tab.html
+++ b/docs/current/modules/widgets/bootstrap-tab.html
@@ -14,6 +14,7 @@
     <script type="text/javascript" src="../../assets/js/bootstrap.js"></script>
     <script type="text/javascript" src="../../assets/js/typeahead.js"></script>
     <script type="text/javascript" src="../../assets/js/main.js"></script>
+    <script type="text/javascript" src="../../assets/js/index.js"></script>
     <script src="http://use.edgefonts.net/source-sans-pro:n3,i3,n4,i4;source-code-pro.js"></script>
 
     <!-- Control the Flash of Unstyled Text (or FOUT) -->

--- a/docs/current/modules/widgets/bootstrap-tooltip.html
+++ b/docs/current/modules/widgets/bootstrap-tooltip.html
@@ -14,6 +14,7 @@
     <script type="text/javascript" src="../../assets/js/bootstrap.js"></script>
     <script type="text/javascript" src="../../assets/js/typeahead.js"></script>
     <script type="text/javascript" src="../../assets/js/main.js"></script>
+    <script type="text/javascript" src="../../assets/js/index.js"></script>
     <script src="http://use.edgefonts.net/source-sans-pro:n3,i3,n4,i4;source-code-pro.js"></script>
 
     <!-- Control the Flash of Unstyled Text (or FOUT) -->

--- a/docs/current/modules/widgets/bootstrap-twipsy-mod.html
+++ b/docs/current/modules/widgets/bootstrap-twipsy-mod.html
@@ -14,6 +14,7 @@
     <script type="text/javascript" src="../../assets/js/bootstrap.js"></script>
     <script type="text/javascript" src="../../assets/js/typeahead.js"></script>
     <script type="text/javascript" src="../../assets/js/main.js"></script>
+    <script type="text/javascript" src="../../assets/js/index.js"></script>
     <script src="http://use.edgefonts.net/source-sans-pro:n3,i3,n4,i4;source-code-pro.js"></script>
 
     <!-- Control the Flash of Unstyled Text (or FOUT) -->

--- a/docs/current/modules/xorigin.html
+++ b/docs/current/modules/xorigin.html
@@ -14,6 +14,7 @@
     <script type="text/javascript" src="../assets/js/bootstrap.js"></script>
     <script type="text/javascript" src="../assets/js/typeahead.js"></script>
     <script type="text/javascript" src="../assets/js/main.js"></script>
+    <script type="text/javascript" src="../assets/js/index.js"></script>
     <script src="http://use.edgefonts.net/source-sans-pro:n3,i3,n4,i4;source-code-pro.js"></script>
 
     <!-- Control the Flash of Unstyled Text (or FOUT) -->


### PR DESCRIPTION
I created a file, index.js which is placed with the other assets for the brackets.io documentation pages.  This file is included as a script in all brackets documentation pages.  It makes the docs pages more like a single page application in that it keeps the place of the left side nav when you click on links and it dynamically loads in the right side content.  I have tested this on my local server and on gh-pages and it works well.

I also added/modified some css rules in main.css to prevent the search box results from getting cut off on the right side and fix other display issues.

More details - https://github.com/mseiler025/brackets-api-docs-spa
