### PR TITLE
Automatically update E4B URL

### DIFF
--- a/index.html
+++ b/index.html
@@ -446,9 +446,8 @@
             cache: false
         });
         $.when(ajaxRequest, i18nLoaded).done(function (data) {
-            data = data[0]; // get actual data
-            var build = data[0];
-            var buildName = build.versionString;
+            var build = data[0][0],
+                buildName = build.versionString;
 
             if (buildName) {
                 var buildNum = buildName.match(/([\d.]+)/);
@@ -460,13 +459,15 @@
                 if (OS !== "OTHER" && buildNum) {
                     var tag = buildName.toLowerCase().split(" ").join("-"),
                         url = "https://github.com/adobe/brackets/releases/" + tag,
-                        urlE4B = "https://github.com/adobe/brackets/releases/download/release-1.6%2Beb4/Brackets.1.6.Extract" + ext;
+                        urlE4B = "https://github.com/adobe/brackets/releases/" + tag + "%2Beb4";
+
                     if (ext) {
-                        url = "https://github.com/adobe/brackets/releases/download/" + tag + "/Brackets." + buildName.split(" ").join(".") + ext;
+                        url = "https://github.com/adobe/brackets/releases/download/" + tag + "/Brackets." + buildName.split(" ")
+                        .join(".") + ext;
+                        urlE4B = "https://github.com/adobe/brackets/releases/download/" + tag + "%2Beb4/Brackets." + buildNum + ".Extract" + ext;
                     }
 
-                    var version_label = buildName.match(/(\d+.*$)/)[1];
-                    $("#download-brackets-version").text(version_label);
+                    $("#download-brackets-version").text(buildNum);
 
                     logAndGo("hero-cta-button", urlE4B, ['_trackEvent', 'E4BDownloads', buildNum, OS]);
                     logAndGo("e4b-secondary-download", urlE4B, ['_trackEvent', 'E4BDownloads', buildNum, OS]);

--- a/index.html
+++ b/index.html
@@ -457,7 +457,7 @@
                 }
 
                 // update button
-                if (OS != "OTHER" && buildNum) {
+                if (OS !== "OTHER" && buildNum) {
                     var tag = buildName.toLowerCase().split(" ").join("-"),
                         url = "https://github.com/adobe/brackets/releases/" + tag,
                         urlE4B = "https://github.com/adobe/brackets/releases/download/release-1.6%2Beb4/Brackets.1.6.Extract" + ext;
@@ -465,11 +465,7 @@
                         url = "https://github.com/adobe/brackets/releases/download/" + tag + "/Brackets." + buildName.split(" ").join(".") + ext;
                     }
 
-                    ///if(OS=="WIN") url = "http://bit.ly/QrVHNc"; // (Temporary) TRACKING WIN
-                    ///else if(OS=="OSX") url = "http://bit.ly/1hQGEsh"; // (Temporary) TRACKING OSX
-
                     var version_label = buildName.match(/(\d+.*$)/)[1];
-                    //if (OS != "UNKNOWN") version_label += " (" + OS + ")";
                     $("#download-brackets-version").text(version_label);
 
                     logAndGo("hero-cta-button", urlE4B, ['_trackEvent', 'E4BDownloads', buildNum, OS]);
@@ -503,7 +499,7 @@
                 downloadStarted = true;
                 setTimeout(function () { window.location.href = _url; }, 1000); // short delay just in case it doesn't get logged
             });
-        }
+        };
     }
 </script>
 


### PR DESCRIPTION
For adobe/brackets#10196. I've checked the releases and their tags and they all follow the same format, so it was simple to generate the URL like we do for the non-Extract bundle.

Also took the opportunity to remove some commented code from 2014 and make minor code improvements.
