### PR TITLE
Adding "Extensions" nav link to connect new extension registry from brackets.io landing page

### DIFF
--- a/contribute.html
+++ b/contribute.html
@@ -76,6 +76,7 @@
                     <a href="contribute.html" class="contribute" data-i18n="nav.contribute">Contribute</a>
                     <a href="docs/current/modules/brackets.html" data-i18n="nav.apidocs">API Docs</a>
                     <a href="http://blog.brackets.io" data-i18n="nav.blog">Blog</a>
+                    <a href="https://registry.brackets.io" data-i18n="nav.extensions">Extensions</a>
                     <a href="https://github.com/adobe/brackets/wiki/Troubleshooting" data-i18n="nav.support">Support</a>
                 </div>
                 <div class="social-links">

--- a/index.html
+++ b/index.html
@@ -93,6 +93,7 @@
                     <a href="contribute.html" class="contribute" data-i18n="nav.contribute">Contribute</a>
                     <a href="docs/current/modules/brackets.html" data-i18n="nav.apidocs">API Docs</a>
                     <a href="http://blog.brackets.io" data-i18n="nav.blog">Blog</a>
+                    <a href="https://registry.brackets.io" data-i18n="nav.extensions">Extensions</a>
                     <a href="https://github.com/adobe/brackets/wiki/Troubleshooting" data-i18n="nav.support">Support</a>
                 </div>
                 <div class="social-links">

--- a/locales/_en/translation.json
+++ b/locales/_en/translation.json
@@ -114,7 +114,8 @@
         "contribute": "Contribute",
         "apidocs": "API Docs",
         "blog": "Blog",
-        "support": "Support"
+        "support": "Support",
+        "extensions": "Extensions"
     },
     "footer": {
         "links": {

--- a/locales/de/translation.json
+++ b/locales/de/translation.json
@@ -114,7 +114,8 @@
         "contribute": "Mach mit",
         "apidocs": "API-Doku",
         "blog": "Blog",
-        "support": "Hilfestellung"
+        "support": "Hilfestellung",
+        "extensions": "Erweiterungen"
     },
     "footer": {
         "links": {

--- a/locales/it/translation.json
+++ b/locales/it/translation.json
@@ -105,7 +105,8 @@
         "contribute": "Contribuisci",
         "apidocs": "Documentazione",
         "blog": "Blog",
-        "support": "Supporto"
+        "support": "Supporto",
+        "extensions": "Estensioni"
     },
     "footer": {
         "links": {

--- a/locales/pt-BR/translation.json
+++ b/locales/pt-BR/translation.json
@@ -105,7 +105,8 @@
         "contribute": "Contribuir",
         "apidocs": "Manual da API",
         "blog": "Blog",
-        "support": "Suporte"
+        "support": "Suporte",
+        "extensions": "Extensões"
     },
     "footer": {
         "links": {


### PR DESCRIPTION
This PR adds "Extensions" nav link  in brackets main landing page to connect our new Extension registry page "https://registry.brackets.io".  Please refer to the attached screenshot .
![extensionlink](https://user-images.githubusercontent.com/12087205/28629895-5531fbc2-7246-11e7-9bdf-60241b489a81.png)
 