### PR TITLE
Revert "Version bump to 1.12"

### DIFF
--- a/index.html
+++ b/index.html
@@ -121,7 +121,7 @@
             <h1><span data-i18n="index.page.hero.description">A modern, open source text editor that understands web design.</span></h1>
             <div id="download">
                 <a id="download-plain-brackets" class="large rounded radius button" href="#">
-					<div data-i18n="[html]index.page.hero.download">Download Brackets <d id="download-brackets-version">1.12</d></div>
+					<div data-i18n="[html]index.page.hero.download">Download Brackets <d id="download-brackets-version">1.11</d></div>
 				</a>
                 <div id="os-alert" class="alert-box radius" data-alert>
                 </div>


### PR DESCRIPTION
Reverts adobe/brackets.io#206.

@adobe/brackets-committers We are reverting Brackets 1.12 release for a brief period to analyse LOC issues reported by users on various platforms. Rest assured this will be fixed on priority and re-establish the 1.12 download links again. 