### PR TITLE
Updated source for private function _disableCache

### DIFF
--- a/docs/current/modules/document/DocumentCommandHandlers.html
+++ b/docs/current/modules/document/DocumentCommandHandlers.html
@@ -1120,28 +1120,31 @@ Make sure we don&#39;t attach this handler if the current window is actually a t
         if (brackets.inBrowser) {
             result.resolve();
         } else {
-            var port = brackets.app.getRemoteDebuggingPort ? brackets.app.getRemoteDebuggingPort() : 9234;
-            Inspector.getDebuggableWindows(&quot;127.0.0.1&quot;, port)
-                .fail(result.reject)
-                .done(function (response) {
-                    var page = response[0];
-                    if (!page || !page.webSocketDebuggerUrl) {
-                        result.reject();
-                        return;
-                    }
-                    var _socket = new WebSocket(page.webSocketDebuggerUrl);
-                    &#x2F;&#x2F; Disable the cache
-                    _socket.onopen = function _onConnect() {
-                        _socket.send(JSON.stringify({ id: 1, method: &quot;Network.setCacheDisabled&quot;, params: { &quot;cacheDisabled&quot;: true } }));
-                    };
-                    &#x2F;&#x2F; The first message will be the confirmation =&gt; disconnected to allow remote debugging of Brackets
-                    _socket.onmessage = function _onMessage(e) {
-                        _socket.close();
-                        result.resolve();
-                    };
-                    &#x2F;&#x2F; In case of an error
-                    _socket.onerror = result.reject;
-                });
+            brackets.app.getRemoteDebuggingPort(function (err, port){
+                if ((!err) &amp;&amp; port &amp;&amp; port &gt; 0) {
+                    Inspector.getDebuggableWindows(&quot;127.0.0.1&quot;, port)
+                        .fail(result.reject)
+                        .done(function (response) {
+                            var page = response[0];
+                            if (!page || !page.webSocketDebuggerUrl) {
+                                result.reject();
+                                return;
+                            }
+                            var _socket = new WebSocket(page.webSocketDebuggerUrl);
+                            &#x2F;&#x2F; Disable the cache
+                            _socket.onopen = function _onConnect() {
+                                _socket.send(JSON.stringify({ id: 1, method: "Network.setCacheDisabled", params: { "cacheDisabled": true } }));
+                            };
+                            &#x2F;&#x2F; The first message will be the confirmation => disconnected to allow remote debugging of Brackets
+                            _socket.onmessage = function _onMessage(e) {
+                                _socket.close();
+                                result.resolve();
+                            };
+                            &#x2F;&#x2F; In case of an error
+                            _socket.onerror = result.reject;
+                        });
+                }
+            });
         }
 
         return result.promise();


### PR DESCRIPTION
Since we updated the signature of function `getRemoteDebuggingPort` to need a callback. And we update function `_disableCache` implementation to use same.
So, updating the source in document to reflect [latest implementation](https://github.com/adobe/brackets/blob/5f406086936d2abf1392b0f77db246b308715d6d/src/document/DocumentCommandHandlers.js#L1639).

